### PR TITLE
Updating the package name to brickflows as pypi won't accept brickflow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @Nike-Inc/brickflow-dev will be requested for
 # review when someone opens a pull request.
-*       @Nike-Inc/brickflow-dev
+*       @Nike-Inc/brickflow-dev @asingamaneni @stikkireddy @newfront

--- a/README.md
+++ b/README.md
@@ -9,15 +9,22 @@
 
 <p align="center">
 BrickFlow is specifically designed to enable the development of Databricks workflows using Python, streamlining the 
-process through a command-line interface (CLI) tool.
+process through a command-line interface (CLI) tool.</p>
 
-<img src="./docs/img/bf_logo_1.png" width="400" height="400">
+<p align="center">
+<img src=https://raw.githubusercontent.com/Nike-Inc/brickflow/master/docs/img/bf_logo_1.png width="400" height="400"></p>
 
 ---
 
 ### Documentation
 
 Brickflow documentation can be found [here](https://engineering.nike.com/brickflow/).
+
+### Installation
+
+```shell
+pip install brickflows
+```
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ process through a command-line interface (CLI) tool.
 
 ### Documentation
 
-Brickflow documentation can be found [here]().
+Brickflow documentation can be found [here](https://engineering.nike.com/brickflow/).
 
 ### Contributors
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,9 +53,7 @@ The project relies on terraform and cdktf to deploy your python projects.
 1. Install brew if not installed already using - [brew-install](https://brew.sh/)
 2. Install node using `brew install node`
 3. Install cdktf-cli via `npm install -g cdktf-cli`
-4. Install the brickflow package via `pip install brickflow[deploy]`
-5. Install the cerberus if needed via `pip install brickflow[cerberus]`
-6. Install the airflow if needed via `pip install brickflow[airflow]`
+4. Install the brickflow package via `pip install brickflows`
 
 ## Setup Project
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "brickflow"
+name = "brickflows"
 version = "0.0.1-pre.36+4a13620"
 description = "Deploy scalable workflows to databricks using python"
 authors = ["Ashok Singamaneni, Sriharsha Tikkireddy"]


### PR DESCRIPTION
The package name in pyproject.toml is changed to Brickflows as pypi is not allowing us to use brickflow.
Error can be found here - 

https://github.com/Nike-Inc/brickflow/actions/runs/5827261247/job/15802969624

![image](https://github.com/Nike-Inc/brickflow/assets/25289866/9c029f11-ccf0-4bc6-957c-f5f0473761bd)
