### PR TITLE
Feature support job schedule pause status

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -392,6 +392,7 @@ class DatabricksBundleCodegen(CodegenInterface):
             return JobsSchedule(
                 quartz_cron_expression=workflow.schedule_quartz_expression,
                 timezone_id=workflow.timezone,
+                pause_status=workflow.schedule_pause_status,
             )
         return None
 

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -161,10 +161,10 @@ class Workflow:
             self.default_cluster = self.clusters[0]
 
         self.schedule_pause_status = self.schedule_pause_status.upper()
-        ALLOWED_SCHEDULE_PAUSE_STATUSES = ["PAUSED", "UNPAUSED"]
-        if self.schedule_pause_status not in ALLOWED_SCHEDULE_PAUSE_STATUSES:
+        allowed_scheduled_pause_statuses = ["PAUSED", "UNPAUSED"]
+        if self.schedule_pause_status not in allowed_scheduled_pause_statuses:
             raise WorkflowConfigError(
-                f"schedule_pause_status must be one of {ALLOWED_SCHEDULE_PAUSE_STATUSES}"
+                f"schedule_pause_status must be one of {allowed_scheduled_pause_statuses}"
             )
 
     # def __hash__(self) -> int:

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -29,6 +29,10 @@ from brickflow.engine.task import (
 from brickflow.engine.utils import wraps_keyerror
 
 
+class WorkflowConfigError(Exception):
+    pass
+
+
 class NoWorkflowComputeError(Exception):
     pass
 
@@ -109,6 +113,7 @@ class Workflow:
     _name: str
     schedule_quartz_expression: Optional[str] = None
     timezone: str = "UTC"
+    schedule_pause_status: str = "UNPAUSED"
     default_cluster: Optional[Cluster] = None
     clusters: List[Cluster] = field(default_factory=lambda: [])
     default_task_settings: TaskSettings = TaskSettings()
@@ -154,6 +159,13 @@ class Workflow:
         if self.default_cluster is None:
             # the default cluster is set to the first cluster if it is not configured
             self.default_cluster = self.clusters[0]
+
+        self.schedule_pause_status = self.schedule_pause_status.upper()
+        ALLOWED_SCHEDULE_PAUSE_STATUSES = ["PAUSED", "UNPAUSED"]
+        if self.schedule_pause_status not in ALLOWED_SCHEDULE_PAUSE_STATUSES:
+            raise WorkflowConfigError(
+                f"schedule_pause_status must be one of {ALLOWED_SCHEDULE_PAUSE_STATUSES}"
+            )
 
     # def __hash__(self) -> int:
     #     import json

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -15,6 +15,7 @@ wf = Workflow(  # (1)!
     # Optional parameters below
     schedule_quartz_expression="0 0/20 0 ? * * *",  # (4)!
     timezone="UTC",  # (5)!
+    schedule_pause_status="PAUSED",  # (15)!
     default_task_settings=TaskSettings(  # (6)!
         email_notifications=EmailNotifications(
             on_start=["email@nike.com"],
@@ -65,6 +66,7 @@ def task_function(*, test="var"):
 12. Suffix for the name of the workflow
 13. Define the common task parameters that can be used in all the tasks
 14. Define a workflow task and associate it to the workflow
+15. Define the schedule pause status. It is defaulted to "UNPAUSED"
 
 ### Clusters
 

--- a/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
@@ -29,6 +29,7 @@ environments:
           schedule:
             quartz_cron_expression: '* * * * *'
             timezone_id: UTC
+            pause_status: "UNPAUSED"
           tags:
             brickflow_project_name: test-project
             brickflow_deployment_mode: Databricks Asset Bundles

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
@@ -29,6 +29,7 @@ environments:
           schedule:
             quartz_cron_expression: '* * * * *'
             timezone_id: UTC
+            pause_status: "UNPAUSED"
           tags:
             brickflow_project_name: test-project
             brickflow_deployment_mode: Databricks Asset Bundles

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
@@ -85,6 +85,7 @@ environments:
           schedule:
             quartz_cron_expression: '* * * * *'
             timezone_id: UTC
+            pause_status: "UNPAUSED"
           tags:
             brickflow_project_name: test-project
             brickflow_deployment_mode: Databricks Asset Bundles

--- a/tests/codegen/expected_bundles/local_bundle.yml
+++ b/tests/codegen/expected_bundles/local_bundle.yml
@@ -26,6 +26,7 @@ environments:
           schedule:
             quartz_cron_expression: '* * * * *'
             timezone_id: UTC
+            pause_status: "UNPAUSED"
           tags:
             brickflow_project_name: test-project
             brickflow_deployment_mode: Databricks Asset Bundles

--- a/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
+++ b/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
@@ -26,6 +26,7 @@ environments:
           schedule:
             quartz_cron_expression: '* * * * *'
             timezone_id: UTC
+            pause_status: "UNPAUSED"
           tags:
             brickflow_project_name: test-project
             brickflow_deployment_mode: Databricks Asset Bundles

--- a/tests/engine/test_workflow.py
+++ b/tests/engine/test_workflow.py
@@ -252,4 +252,6 @@ class TestWorkflow:
                 clusters=[Cluster("name", "spark", "vm-node")],
                 schedule_pause_status="invalid",
             )
-        assert "schedule_pause_status must be one of ['PAUSED', 'UNPAUSED']" == str(excinfo.value)
+        assert "schedule_pause_status must be one of ['PAUSED', 'UNPAUSED']" == str(
+            excinfo.value
+        )

--- a/tests/engine/test_workflow.py
+++ b/tests/engine/test_workflow.py
@@ -16,6 +16,7 @@ from brickflow.engine.workflow import (
     ServicePrincipal,
     Workflow,
     NoWorkflowComputeError,
+    WorkflowConfigError,
 )
 from tests.engine.sample_workflow import wf, task_function
 
@@ -226,3 +227,28 @@ class TestWorkflow:
 
         assert len(wf1.graph.nodes) == 2
         assert len(wf.graph.nodes) == 10
+
+    def test_schedule_run_status_workflow(self):
+        this_wf = Workflow("test", clusters=[Cluster("name", "spark", "vm-node")])
+        assert this_wf.schedule_pause_status == "UNPAUSED"
+
+        this_wf = Workflow(
+            "test",
+            clusters=[Cluster("name", "spark", "vm-node")],
+            schedule_pause_status="PAUSED",
+        )
+        assert this_wf.schedule_pause_status == "PAUSED"
+
+        this_wf = Workflow(
+            "test",
+            clusters=[Cluster("name", "spark", "vm-node")],
+            schedule_pause_status="paused",
+        )
+        assert this_wf.schedule_pause_status == "PAUSED"
+
+        with pytest.raises(WorkflowConfigError):
+            Workflow(
+                "test",
+                clusters=[Cluster("name", "spark", "vm-node")],
+                schedule_pause_status="invalid",
+            )

--- a/tests/engine/test_workflow.py
+++ b/tests/engine/test_workflow.py
@@ -246,9 +246,10 @@ class TestWorkflow:
         )
         assert this_wf.schedule_pause_status == "PAUSED"
 
-        with pytest.raises(WorkflowConfigError):
+        with pytest.raises(WorkflowConfigError) as excinfo:
             Workflow(
                 "test",
                 clusters=[Cluster("name", "spark", "vm-node")],
                 schedule_pause_status="invalid",
             )
+        assert "schedule_pause_status must be one of ['PAUSED', 'UNPAUSED']" == str(excinfo.value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To give the user authority to decide if the workflow should be paused or unpaused when the workflow is deployed. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#39 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will enable users to provide the below options for `schedule_pause_status` in workflow object
`schedule_pause_status = {"paused"|"unpaused"|"PAUSED"|"UNPAUSED"}`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated unitests and also tested manually by deploying a workflow in my workspace

## Screenshots (if appropriate):

![image](https://github.com/Nike-Inc/brickflow/assets/25289866/8bfa403b-1d96-415d-9e39-324e3e2d2b45)

![image](https://github.com/Nike-Inc/brickflow/assets/25289866/8691265e-87bd-4ad2-84f0-faa7c058fb2a)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
