### PR TITLE
Fix  issue 48 and 60 related to the WorkflowDependencySensor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ fmt:
 	@poetry run black .
 
 check: black-check mypy
-	@poetry run prospector --profile prospector.yaml
+	@poetry run prospector --profile prospector.yaml --no-autodetect
 
 mypy:
 	@poetry run mypy

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -40,6 +40,7 @@ To provide this capability, brickflow offers a parameter to do this:
 ## How do I wait for a workflow to finish before kicking off my own workflow's tasks?
 
 ```python
+from brickflow.context import ctx
 from brickflow_plugins import WorkflowDependencySensor
 
 wf = Workflow(...)
@@ -47,10 +48,10 @@ wf = Workflow(...)
 
 @wf.task
 def wait_on_workflow(*args):
+    api_token_key = ctx.dbutils.secrets.get("brickflow-demo-tobedeleted", "api_token_key")
     sensor = WorkflowDependencySensor(
         databricks_host="https://your_workspace_url.cloud.databricks.com",
-        databricks_secrets_scope="brickflow-demo-tobedeleted",
-        databricks_secrets_key="api_token_key",
+        databricks_token=api_token_key,
         dependency_job_id=job_id,
         poke_interval=20,
         timeout=60,

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -319,6 +319,7 @@ def airflow_external_task_dependency_sensor():
 Wait for a workflow to finish before kicking off the current workflow's tasks
 
 ```python title="workflow_dependency_sensor"
+from brickflow.context import ctx
 from brickflow_plugins import WorkflowDependencySensor
 
 wf = Workflow(...)
@@ -326,10 +327,10 @@ wf = Workflow(...)
 
 @wf.task
 def wait_on_workflow(*args):
+   api_token_key = ctx.dbutils.secrets.get("brickflow-demo-tobedeleted", "api_token_key")
    sensor = WorkflowDependencySensor(
       databricks_host="https://your_workspace_url.cloud.databricks.com",
-      databricks_secrets_scope="brickflow-demo-tobedeleted",
-      databricks_secrets_key="api_token_key",
+      databricks_token=api_token_key,
       dependency_job_id=job_id,
       poke_interval=20,
       timeout=60,


### PR DESCRIPTION
## Description
This PR contains following changes

- Changes to WorkflowDependencySensor such that other secret managers can be used to specify the api token
- Fix bug in WorkflowDependencySensor where start_time_from was in unix seconds i.s.o millisecond
-  Put `--no-autodetect` in make check of Makefile cause otherwise prospector needs django which isn't used. I needed this to get `make check` running on my machine but not sure what you guys think of this

## Related Issue

- [Issue 48](https://github.com/Nike-Inc/brickflow/issues/48)
- [Issue 60](https://github.com/Nike-Inc/brickflow/issues/60)

## Motivation and Context
At this point in time the WorkflowDependencySensor doesn't work at all which blocks multiple users of brickflow.
I know that in the future this functionality will not be needed anymore in brickflow as it's become Databricks native so can be achieved through asset bundles. This however needs development at brickflow side so this PR fixes the issues we face till this is done.

## How Has This Been Tested?
I build my own wheel based on this PR and tested it extensively on a workflow making use of the WorkflowDependencySensor

## Screenshots (if appropriate):

## Types of changes
Due to the change in how the token gets handled in `WorkflowDependencySensor` users will need to adapt their code when they upgrade. I however think there are no users of this feature at the moment as it's not working right now.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
