### PR TITLE
added fix for import block type to support both str and int and added…

### DIFF
--- a/tests/codegen/test_databricks_bundle.py
+++ b/tests/codegen/test_databricks_bundle.py
@@ -24,6 +24,7 @@ from brickflow.codegen.databricks_bundle import (
     DatabricksBundleImportMutator,
     DatabricksBundleCodegen,
     ImportBlock,
+    ImportManager,
 )
 from brickflow.engine.project import Stage, Project
 from brickflow.engine.task import NotebookTask
@@ -410,3 +411,21 @@ class TestBundleCodegen:
         assert (
             jobs is not None and jobs[job_name].name == f"{fake_user_name}_{job_name}"
         )
+
+    def test_import_blocks(self):
+        # Databricks object ids are either strings or integers
+        block1 = ImportBlock(to="test", id_=1)
+        block2 = ImportBlock(to="test_2", id_="test")
+        blocks = [block1, block2]
+        expected_output = """import { 
+  to = test 
+  id = "1" 
+}
+
+import { 
+  to = test_2 
+  id = "test" 
+}"""
+        assert (
+            ImportManager.create_import_str(blocks).strip() == expected_output.strip()
+        ), "Import blocks are not equal"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix #74 


## Motivation and Context
Import block support both str and int types as valid ids and added test.

## How Has This Been Tested?
Unit testing added for constructing the object and generation of the terraform import file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
