### PR TITLE
[FEATURE] Optional auth for AutosysSensor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Thanks to the contributors who helped on this project apart from the authors
 * [Brent (Johnson) Spetner](https://www.linkedin.com/in/brentjohnsoneng/)
 * [Dmitrii Grigorev](https://www.linkedin.com/in/dmitrii-grigorev-074739135/)
 * [Chanukya Konuganti](https://www.linkedin.com/in/chanukyakonuganti/)
+* [Maxim Mityutko](https://www.linkedin.com/in/mityutko/)
 
 # Honorary Mentions
 Thanks to the team below for invaluable insights and support throughout the initial release of this project

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -345,7 +345,6 @@ class AutosysSensor(BaseSensorOperator):
         url: str,
         job_name: str,
         poke_interval: int,
-        airflow_cluster_auth: AirflowClusterAuth = None,
         time_delta: Union[timedelta, dict] = {"days": 0},
         *args,
         **kwargs,
@@ -354,7 +353,6 @@ class AutosysSensor(BaseSensorOperator):
         self.url = url
         self.job_name = job_name
         self.poke_interval = poke_interval
-        self.airflow_auth = airflow_cluster_auth
         self.time_delta = time_delta
         self.url = self.url + self.job_name
 
@@ -373,9 +371,6 @@ class AutosysSensor(BaseSensorOperator):
             "Accept": "application/json",
             "cache-control": "no-cache",
         }
-        if self.airflow_auth:
-            token = self.airflow_auth.get_access_token()
-            headers["Authorization"] = f"Bearer {token}"
 
         response = requests.get(
             self.url,


### PR DESCRIPTION
Closes #86 

## Description
Making authentication optional for AutosysSensor. If `airflow_cluster_auth` is provided, it will be used to obtain the authentication token. The token then will be included in the request headers. Otherwise the call will happen without auth.

## Related Issue
[[FEATURE] Optional authentication for AutosysSensor](https://github.com/Nike-Inc/brickflow/issues/86)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Skip authentication token acquisition if it's not required, reduces the amount of calls to the credentials store and / or authentication service, eg. Okta. Streamlines and simplifies user experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built wheel with the change, used wheel as a cluster library instead of the original brickflow distribution from PyPi. Executed workflow with AutosysSensor both with and without authentication. Both scenarios succeeded.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
