### PR TITLE
[BUG] Change date/time parsing in AutosysSensor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Thanks to the contributors who helped on this project apart from the authors
 * [Brent (Johnson) Spetner](https://www.linkedin.com/in/brentjohnsoneng/)
 * [Dmitrii Grigorev](https://www.linkedin.com/in/dmitrii-grigorev-074739135/)
 * [Chanukya Konuganti](https://www.linkedin.com/in/chanukyakonuganti/)
+* [Maxim Mityutko](https://www.linkedin.com/in/mityutko/)
 
 # Honorary Mentions
 Thanks to the team below for invaluable insights and support throughout the initial release of this project

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -387,7 +387,9 @@ class AutosysSensor(BaseSensorOperator):
         else:
             status = response.json()["status"][:2].upper()
 
-            last_end_timestamp = parse(response.json()["lastEndUTC"]).replace(tzinfo=pytz.UTC)
+            last_end_timestamp = parse(response.json()["lastEndUTC"]).replace(
+                tzinfo=pytz.UTC
+            )
 
             time_delta = (
                 self.time_delta
@@ -399,11 +401,15 @@ class AutosysSensor(BaseSensorOperator):
             run_timestamp = execution_timestamp - time_delta
 
             if "SU" in status and last_end_timestamp >= run_timestamp:
-                logging.info(f"Last End: {last_end_timestamp}, Run Timestamp: {run_timestamp}")
+                logging.info(
+                    f"Last End: {last_end_timestamp}, Run Timestamp: {run_timestamp}"
+                )
                 logging.info("Success criteria met. Exiting")
                 return True
             else:
-                logging.info(f"Last End: {last_end_timestamp}, Run Timestamp: {run_timestamp}")
+                logging.info(
+                    f"Last End: {last_end_timestamp}, Run Timestamp: {run_timestamp}"
+                )
                 time.sleep(self.poke_interval)
                 logging.info("Poking again")
                 AutosysSensor.poke(self, context)


### PR DESCRIPTION
Closes #88 
The date/time parsing in AutosysSensor is format sensitive. We can use `dateutil.parser` to make the process format agnostic.

## Description
Using the `dateutil.parser` to make internal logic of AutosysSensor agnostic to the format of the `execution_date` provided by the Brickflow context; and using the same approach to parse `lastEndUTC` string to timestamp.

## Related Issue
[[BUG] Faulty execution_date parser in AutosysSensor](https://github.com/Nike-Inc/brickflow/issues/88)

## Motivation and Context
This solves the cases when/if upstream Autosys API changes and the `lastEndUTC` timestamp is provided in different format;
It solved error when parsing the `execution_date` which format may be different depending on how the job is triggered.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
