### PR TITLE
added fix for snowflake operator to accept authenticator and make parameters optional based on load_type

### DIFF
--- a/brickflow/engine/task.py
+++ b/brickflow/engine/task.py
@@ -803,6 +803,7 @@ def get_brickflow_libraries(enable_plugins: bool = False) -> List[TaskLibrary]:
         return [
             bf_lib,
             PypiTaskLibrary("apache-airflow==2.6.3"),
+            PypiTaskLibrary("snowflake==0.5.1"),
             MavenTaskLibrary("com.cronutils:cron-utils:9.2.0"),
         ]
     else:

--- a/brickflow_plugins/databricks/uc_to_snowflake_operator.py
+++ b/brickflow_plugins/databricks/uc_to_snowflake_operator.py
@@ -264,7 +264,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
 
     above code snippet expects the data as follows
     databricks_secrets_psc contains username, password, account, warehouse, database and role keys with snowflake values
-    parameters = {'load_type':'incremental','dbx_catalog':'sample_catalog','dbx_schema':'sample_schema',
+    parameters = {'load_type':'incremental','dbx_catalog':'sample_catalog','dbx_database':'sample_schema',
                       'dbx_table':'sf_operator_1', 'sf_schema':'stage','sf_table':'SF_OPERATOR_1',
                       'sf_grantee_roles':'downstream_read_role', 'incremental_filter':"dt='2023-10-22'",
                       'sf_cluster_keys':''}
@@ -272,7 +272,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
     in the parameters dictionary we have mandatory keys as follows
     load_type(required): incremental/full
     dbx_catalog (required): name of the catalog in unity
-    dbx_schema  (required): schema name within the catalog
+    dbx_database  (required): schema name within the catalog
     dbx_table   (required): name of the object in the schema
     sf_database (optional): database name in snowflake
     sf_schema   (required): snowflake schema in the database provided as part of scope
@@ -350,7 +350,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
             mandatory_keys = (
                 "load_type",
                 "dbx_catalog",
-                "dbx_schema",
+                "dbx_database",
                 "dbx_table",
                 "sf_schema",
                 "sf_table",
@@ -426,7 +426,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
         df = ctx.spark.sql(
             """select * from {}.{}.{} where {}""".format(
                 self.parameters["dbx_catalog"],
-                self.parameters["dbx_schema"],
+                self.parameters["dbx_database"],
                 self.parameters["dbx_table"],
                 self.dbx_data_filter,
             )

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -68,8 +68,9 @@ wf = Workflow(...)
 @wf.task
 def run_snowflake_queries(*args):
   sf_query_run = SnowflakeOperator(
-    secret_cope = "your_databricks secrets scope name",
-    input_params = {'query':"comma_seprated_list_of_queries"}
+    secret_scope = "your_databricks secrets scope name",
+    query_string = "string of queries separated by semicolon(;)",
+    parameters={"key1":"value1", "key2":"value2"}
   )
   sf_query_run.execute()
 ```
@@ -85,7 +86,7 @@ wf = Workflow(...)
 def copy_from_uc_sf(*args):
   uc_to_sf_copy = UcToSnowflakeOperator(
     secret_scope = "your_databricks secrets scope name",
-    uc_parameters = {'load_type':'incremental','dbx_catalog':'sample_catalog','dbx_database':'sample_schema',
+    parameters = {'load_type':'incremental','dbx_catalog':'sample_catalog','dbx_database':'sample_schema',
                       'dbx_table':'sf_operator_1', 'sf_schema':'stage','sf_table':'SF_OPERATOR_1',
                       'sf_grantee_roles':'downstream_read_role', 'incremental_filter':"dt='2023-10-22'",
                       'sf_cluster_keys':''}

--- a/examples/brickflow_examples/workflows/demo_wf.py
+++ b/examples/brickflow_examples/workflows/demo_wf.py
@@ -273,7 +273,7 @@ def airflow_autosys_sensor():
 def run_snowflake_queries(*args):
     uc_to_sf_copy = UcToSnowflakeOperator(
         secret_cope="sample_scope",
-        uc_parameters={
+        parameters={
             "load_type": "incremental",
             "dbx_catalog": "sample_catalog",
             "dbx_database": "sample_schema",
@@ -282,6 +282,7 @@ def run_snowflake_queries(*args):
             "sf_table": "SF_OPERATOR_1",
             "sf_grantee_roles": "downstream_read_role",
             "incremental_filter": "dt='2023-10-22'",
+            "dbx_data_filter": "run_dt='2023-10-21'",
             "sf_cluster_keys": "",
         },
     )
@@ -291,7 +292,9 @@ def run_snowflake_queries(*args):
 @wf.task
 def run_snowflake_queries(*args):
     sf_query_run = SnowflakeOperator(
-        secret_cope="sample_scope", input_params={"query": "select * from table"}
+        secret_cope="sample_scope",
+        query_string="select * from table; insert into table1 select * from $database.table2",
+        parameters={"database": "sample_db"},
     )
     sf_query_run.execute()
 

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
@@ -34,6 +34,9 @@ targets:
                 - pypi:
                     package: apache-airflow==2.6.3
                     repo: null
+                - pypi:
+                    package: snowflake==0.5.1
+                    repo: null
                 - maven:
                     coordinates: com.cronutils:cron-utils:9.2.0
                     exclusions: null

--- a/tests/engine/test_task.py
+++ b/tests/engine/test_task.py
@@ -390,7 +390,7 @@ class TestTask:
     def test_get_brickflow_libraries(self):
         settings = BrickflowProjectDeploymentSettings()
         settings.brickflow_project_runtime_version = "1.0.0"
-        assert len(get_brickflow_libraries(enable_plugins=True)) == 3
+        assert len(get_brickflow_libraries(enable_plugins=True)) == 4
         assert len(get_brickflow_libraries(enable_plugins=False)) == 1
         lib = get_brickflow_libraries(enable_plugins=False)[0].dict
         expected = {
@@ -406,7 +406,7 @@ class TestTask:
         settings = BrickflowProjectDeploymentSettings()
         tag = "1.0.1rc1234"
         settings.brickflow_project_runtime_version = tag
-        assert len(get_brickflow_libraries(enable_plugins=True)) == 3
+        assert len(get_brickflow_libraries(enable_plugins=True)) == 4
         assert len(get_brickflow_libraries(enable_plugins=False)) == 1
         lib = get_brickflow_libraries(enable_plugins=False)[0].dict
         expected = {
@@ -422,7 +422,7 @@ class TestTask:
         settings = BrickflowProjectDeploymentSettings()
         tag = "somebranch"
         settings.brickflow_project_runtime_version = tag
-        assert len(get_brickflow_libraries(enable_plugins=True)) == 3
+        assert len(get_brickflow_libraries(enable_plugins=True)) == 4
         assert len(get_brickflow_libraries(enable_plugins=False)) == 1
         lib = get_brickflow_libraries(enable_plugins=False)[0].dict
         expected = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added code to handle authenticator issue posted in issue #85 
Added snowflake library installation to avoid initialization failures for brickflow plugins 
enhanced the code to accept parameters based on load_type instead of making every parameter mandatory. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #85 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At this point code is failing for user id's which require extra authentication mechanism which is blocking multiple brickflow consumers. As we added snowflake operator to initialize with brickflow_plugins it is looking for snowflake library and causing issues to some customers, fixing this issue. Current version of the operator expects optional parameters like sf_cluster_keys, incremental_filter, sf_grantee_roles even when they are not required for customers and causing issues. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a wheel file , workflow and tested with user id that require and doesn't require extra authentication. ran multiple test cases with different combination of input params. created a notebook with operator code and ran multiple manual unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
