### PR TITLE
fix ignore permission error due to most likely being caused by shared clusters

### DIFF
--- a/brickflow/resolver/__init__.py
+++ b/brickflow/resolver/__init__.py
@@ -72,6 +72,8 @@ def get_relative_path_to_brickflow_root() -> None:
             _ilog.info("Sys path set to: %s", str(sys.path))
         except BrickflowRootNotFound:
             _ilog.info("Unable to find for path: %s", path)
+        except PermissionError:
+            _ilog.info("Most likely not accessible due to shared cluster: %s", path)
 
 
 def get_notebook_ws_path(dbutils: Optional[Any]) -> Optional[str]:


### PR DESCRIPTION
This resolves the permissions issues in brickflow on shared clusters.

## Description
This 

## Related Issue
Resolves issue #31 and #96 

## How Has This Been Tested?
Unit test has been included

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
