### PR TITLE
[FIX] Cluster `policy_id` converted to scientific notation

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -666,5 +666,11 @@ class DatabricksBundleCodegen(CodegenInterface):
         if self.env == BrickflowDefaultEnvs.LOCAL.value:
             # it should use the bundles project env field as that is the folder bundles makes
             ImportManager.create_import_tf(get_bundles_project_env(), self.imports)
+
+        def quoted_presenter(dumper, data):  # type: ignore[no-untyped-def]
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
+
+        yaml.add_representer(str, quoted_presenter)
+
         with open("bundle.yml", "w", encoding="utf-8") as f:
             f.write(yaml.dump(bundle.dict(exclude_unset=True)))


### PR DESCRIPTION
Closes #106 

## Description
Adding custom representer for yaml.dump to ensure that string values are enclosed in the quotation marks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#106 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If any string value in the generated `bundle.yaml` can be interpretted as something other than a string, e.g. number in scientific notation, deployment to Databricks may / will fail. It definitly guarantees failed deployment when this case occurs for `policy_id` for cluster.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've used local installation of brickflow with this change to generate the updated bundle and successfully deployed it Databricks. Workflow was successfully created with the correct cluster setup and any other expected configuration.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
