### PR TITLE
[FEATURE] Sanitise input of the `brickflow_internal_only_run_tasks` parameter

### DIFF
--- a/brickflow/engine/task.py
+++ b/brickflow/engine/task.py
@@ -4,6 +4,7 @@ import base64
 import dataclasses
 import functools
 import inspect
+import json
 import logging
 import textwrap
 from dataclasses import dataclass, field
@@ -681,7 +682,26 @@ class Task:
         )
         if selected_tasks is None or selected_tasks == "":
             return False, None
-        selected_task_list = selected_tasks.split(",")
+
+        if selected_tasks.startswith("[") and selected_tasks.endswith("]"):
+            try:
+                selected_task_list = json.loads(selected_tasks)
+            except json.JSONDecodeError:
+                selected_task_list = []
+                _ilog.info(
+                    "Invalid JSON list in `brickflow_internal_only_run_tasks` parameter. Nothing will be skipped."
+                )
+            except Exception as e:
+                selected_task_list = []
+                _ilog.info(
+                    "Error parsing `brickflow_internal_only_run_tasks` parameter as JSON, nothing to skip. Error: %s",
+                    str(e),
+                )
+        else:
+            selected_task_list = selected_tasks.split(",")
+
+        selected_task_list = [task.strip() for task in selected_task_list]
+
         if self.name not in selected_task_list:
             return (
                 True,

--- a/tests/engine/test_task.py
+++ b/tests/engine/test_task.py
@@ -174,9 +174,16 @@ class TestTask:
         assert reason is None
         ctx._configure()
 
+    @pytest.mark.parametrize(
+        "tasks",
+        [
+            "somethingelse",  # other task
+            f"[{task_function_4.__name__}]",  # invalid JSON list defaults to no skip
+        ],
+    )
     @patch("brickflow.context.ctx.get_parameter")
-    def test_skip_not_selected_task(self, dbutils):
-        dbutils.value = "sometihngelse"
+    def test_skip_not_selected_task(self, dbutils, tasks):
+        dbutils.return_value = tasks
         skip, reason = wf.get_task(
             task_function_4.__name__
         )._skip_because_not_selected()
@@ -189,9 +196,18 @@ class TestTask:
         )
         assert wf.get_task(task_function_4.__name__).execute() is None
 
+    @pytest.mark.parametrize(
+        "tasks",
+        [
+            task_function_4.__name__,  # clean string
+            f'["{task_function_4.__name__}"]',  # clean JSON list
+            f'["  {task_function_4.__name__}  "]',  # spaced JSON list
+            f"  {task_function_4.__name__}  ",  # spaced string
+        ],
+    )
     @patch("brickflow.context.ctx.get_parameter")
-    def test_no_skip_selected_task(self, dbutils: Mock):
-        dbutils.return_value = task_function_4.__name__
+    def test_no_skip_selected_task(self, dbutils, tasks):
+        dbutils.return_value = tasks
         skip, reason = wf.get_task(
             task_function_4.__name__
         )._skip_because_not_selected()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clean user input to `brickflow_internal_only_run_tasks` parameter:
- trim whitespaces
- allow valid JSON list as input

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#105 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Usability improvement

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
