### PR TITLE
[FEATURE] Add `WorkflowTaskDependencySensor`

### DIFF
--- a/brickflow/engine/utils.py
+++ b/brickflow/engine/utils.py
@@ -1,6 +1,10 @@
 import functools
-from typing import Callable, Type, List, Iterator
+from typing import Callable, Type, List, Iterator, Union
 
+import requests
+from pydantic import SecretStr
+
+from brickflow.context import ctx
 from brickflow.hints import propagate_hint
 
 
@@ -28,3 +32,51 @@ def get_properties(some_obj: Type) -> List[str]:
                 yield k
 
     return list(_property_iter())
+
+
+def get_job_id(
+    job_name: str, workspace_url: str, api_token: Union[str, SecretStr]
+) -> Union[str, None]:
+    """
+    Get the job id from the specified Databricks workspace for a given job name.
+
+    Parameters
+    ----------
+    job_name: str
+        Job name (case-insensitive)
+    workspace_url: str
+        Databricks workspace URL
+    api_token: str
+        Databricks API token
+    Returns
+    -------
+    str
+        Databricks job id
+    """
+    ctx.log.info("Searching job id for job name: %s", job_name)
+
+    api_token = (
+        api_token.get_secret_value() if isinstance(api_token, SecretStr) else api_token
+    )
+
+    workspace_url = workspace_url.rstrip("/")
+    response = requests.get(
+        url=f"{workspace_url}/api/2.1/jobs/list",
+        headers={"Authorization": f"Bearer {api_token}"},
+        params={"name": job_name},
+        timeout=10,
+    )
+
+    data = response.json()
+    if response.status_code == 200:
+        if "jobs" in data:
+            job_id = data["jobs"][0].get("job_id")
+            ctx.log.info("Job id for job '%s' is %s", job_name, job_id)
+            return job_id
+        else:
+            raise ValueError(f"No job found with name '{job_name}'")
+    else:
+        ctx.log.info(
+            "Request returned a %s code, with data '%s'", response.status_code, data
+        )
+        return None

--- a/brickflow_plugins/__init__.py
+++ b/brickflow_plugins/__init__.py
@@ -33,6 +33,7 @@ from brickflow_plugins.airflow.operators.native_operators import (
 )
 from brickflow_plugins.databricks.workflow_dependency_sensor import (
     WorkflowDependencySensor,
+    WorkflowTaskDependencySensor,
 )
 from brickflow_plugins.databricks.uc_to_snowflake_operator import (
     SnowflakeOperator,
@@ -69,6 +70,7 @@ __all__: List[str] = [
     "BranchPythonOperator",
     "ShortCircuitOperator",
     "WorkflowDependencySensor",
+    "WorkflowTaskDependencySensor",
     "SnowflakeOperator",
     "UcToSnowflakeOperator",
     "TableauRefreshDataSourceOperator",

--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -195,15 +195,21 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
 
     def __init__(
         self,
+        databricks_host: str,
+        databricks_token: Union[str, SecretStr],
+        dependency_job_id: int,
         dependency_task_name: str,
+        delta: timedelta,
+        timeout_seconds: int,
+        poke_interval_seconds: int = 60,
     ):
         super().__init__(
-            databricks_host=ctx.databricks_host,
-            databricks_token=ctx.databricks_token,
-            dependency_job_id=ctx.dependency_job_id,
-            delta=ctx.delta,
-            timeout_seconds=ctx.timeout_seconds,
-            poke_interval_seconds=ctx.poke_interval_seconds,
+            databricks_host=databricks_host,
+            databricks_token=databricks_token,
+            dependency_job_id=dependency_job_id,
+            delta=delta,
+            timeout_seconds=timeout_seconds,
+            poke_interval_seconds=poke_interval_seconds,
         )
 
         self.dependency_task_name = dependency_task_name

--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -225,7 +225,7 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
             "limit": 25,
             "job_id": self.dependency_job_id,
             "start_time_from": self.get_execution_start_time_unix_milliseconds(),
-            "expand_tasks": True,
+            "expand_tasks": "true",
         }
 
         while True:

--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -9,6 +9,7 @@ from warnings import warn
 import requests
 from pydantic import SecretStr
 from requests.adapters import HTTPAdapter
+from databricks.sdk import WorkspaceClient
 
 from brickflow.context import ctx
 from brickflow.engine.utils import get_job_id
@@ -78,6 +79,10 @@ class WorkflowDependencySensor:
         self.dependency_job_id = dependency_job_id
         self.dependency_job_name = dependency_job_name
 
+        self._workspace_obj = WorkspaceClient(
+            host=self.databricks_host, token=self.databricks_token.get_secret_value()
+        )
+
     def get_retry_class(self, max_retries):
         from urllib3 import Retry
 
@@ -112,23 +117,17 @@ class WorkflowDependencySensor:
         return session
 
     def get_execution_start_time_unix_milliseconds(self) -> int:
-        session = self.get_http_session()
-        url = f"{self.databricks_host.rstrip('/')}/api/2.1/jobs/runs/get"
-        headers = {
-            "Authorization": f"Bearer {self.databricks_token.get_secret_value()}",
-            "Content-Type": "application/json",
-        }
         run_id = ctx.dbutils_widget_get_or_else("brickflow_parent_run_id", None)
         if run_id is None:
             raise WorkflowDependencySensorException(
                 "run_id is empty, brickflow_parent_run_id parameter is not found "
                 "or no value present"
             )
-        params = {"run_id": run_id}
-        resp = session.get(url, params=params, headers=headers).json()
+
+        run = self._workspace_obj.jobs.get_run(run_id=run_id)
 
         # Convert Unix timestamp in milliseconds to datetime object to easily incorporate the delta
-        start_time = datetime.fromtimestamp(resp["start_time"] / 1000)
+        start_time = datetime.fromtimestamp(run.start_time / 1000)
         execution_start_time = start_time - self.delta
 
         # Convert datetime object back to Unix timestamp in miliseconds
@@ -148,8 +147,8 @@ class WorkflowDependencySensor:
     @property
     def _get_job_id(self):
         return get_job_id(
-            workspace_url=self.databricks_host,
-            api_token=self.databricks_token,
+            host=self.databricks_host,
+            token=self.databricks_token,
             job_name=self.dependency_job_name,
         )
 
@@ -223,12 +222,12 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
 
     def __init__(
         self,
-        databricks_host: str,
-        databricks_token: Union[str, SecretStr],
         dependency_job_name: str,
         dependency_task_name: str,
         delta: timedelta,
         timeout_seconds: int,
+        databricks_host: str = None,
+        databricks_token: Union[str, SecretStr] = None,
         poke_interval_seconds: int = 60,
     ):
         super().__init__(
@@ -245,47 +244,28 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
     def execute(self):
         self.dependency_job_id = self._get_job_id
 
-        session = self.get_http_session()
-        url = f"{self.databricks_host.rstrip('/')}/api/2.1/jobs/runs/list"
-        headers = {
-            "Authorization": f"Bearer {self.databricks_token.get_secret_value()}",
-            "Content-Type": "application/json",
-        }
-        params = {
-            "limit": 25,
-            "job_id": self.dependency_job_id,
-            "start_time_from": self.get_execution_start_time_unix_milliseconds(),
-            "expand_tasks": "true",
-        }
-
         while True:
-            page_index = 0
-            has_more = True
-            while has_more is True:
-                resp = session.get(url, params=params, headers=headers).json()
-                for run in resp.get("runs", []):
-                    for task in run.get("tasks", []):
-                        if task.get("task_key") == self.dependency_task_name:
-                            task_state = task.get("state", {}).get("result_state", None)
-                            self.log.info(
-                                f"Found the run_id '{run['run_id']}' and '{self.dependency_task_name}' "
-                                f"task with state: {task_state}"
-                            )
-                            if task_state == "SUCCESS":
-                                self.log.info(
-                                    f"Found a successful run: {run['run_id']}"
-                                )
-                                return
+            runs_list = self._workspace_obj.jobs.list_runs(
+                job_id=self.dependency_job_id,
+                limit=25,
+                start_time_from=self.get_execution_start_time_unix_milliseconds(),
+                expand_tasks=True,
+            )
 
-                has_more = resp.get("has_more", False)
-                if has_more:
-                    params["page_token"] = resp["next_page_token"]
-                self.log.info(
-                    f"This is page_index: {page_index}, this is has_more: {has_more}"
-                )
-                page_index += 1
+            for run in runs_list:
+                for task in run.tasks:
+                    if task.task_key == self.dependency_task_name:
+                        task_state = task.state.result_state
+                        self.log.info(
+                            f"Found the run_id '{run.run_id}' and '{self.dependency_task_name}' "
+                            f"task with state: {task_state.value}"
+                        )
+                        if task_state.value == "SUCCESS":
+                            self.log.info(f"Found a successful run: {run.run_id}")
+                            return
 
             self.log.info("Didn't find a successful task run yet...")
+
             if (
                 self.timeout is not None
                 and (time.time() - self.start_time) > self.timeout

--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -178,7 +178,7 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
     This is used to have dependencies on the specific task within a databricks workflow
 
     Example Usage in your brickflow task:
-        service_principle_pat = ctx.dbutils.secrets.get("brickflow-demo-tobedeleted", "service_principle_id")
+        service_principle_pat = ctx.dbutils.secrets.get("scope", "service_principle_id")
         WorkflowDependencySensor(
             databricks_host=https://your_workspace_url.cloud.databricks.com,
             databricks_token=service_principle_pat,

--- a/docs/api/workflow_dependency_sensor.md
+++ b/docs/api/workflow_dependency_sensor.md
@@ -6,6 +6,9 @@ search:
 ::: brickflow_plugins.databricks.workflow_dependency_sensor
     handler: python
     options:
+        members:
+            - WorkflowDependencySensor
+            - WorkflowTaskDependencySensor
         filters:
             - "!^_[^_]"
             - "!^__[^__]"

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -59,6 +59,31 @@ def wait_on_workflow(*args):
     )
     sensor.execute()
 ```
+
+## How do I wait for a specific task in a workflow to finish before kicking off my own workflow's tasks?
+
+```python
+from brickflow.context import ctx
+from brickflow_plugins import WorkflowTaskDependencySensor
+
+wf = Workflow(...)
+
+
+@wf.task
+def wait_on_workflow(*args):
+    api_token_key = ctx.dbutils.secrets.get("scope", "api_token_key")
+    sensor = WorkflowTaskDependencySensor(
+        databricks_host="https://your_workspace_url.cloud.databricks.com",
+        databricks_token=api_token_key,
+        dependency_job_id=job_id,
+        dependency_task_name="foo",
+        poke_interval=20,
+        timeout=60,
+        delta=timedelta(days=1)
+    )
+    sensor.execute()
+```
+
 ## How do I run a sql query on snowflake from DBX?
 ```python
 from brickflow_plugins import SnowflakeOperator

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -397,6 +397,32 @@ def wait_on_workflow(*args):
    sensor.execute()
 ```
 
+#### Workflow Task Dependency Sensor
+
+Wait for a specific task in a workflow to finish before kicking off the current workflow's tasks
+
+```python title="workflow_dependency_sensor"
+from brickflow.context import ctx
+from brickflow_plugins import WorkflowTaskDependencySensor
+
+wf = Workflow(...)
+
+
+@wf.task
+def wait_on_workflow(*args):
+   api_token_key = ctx.dbutils.secrets.get("scope", "api_token_key")
+   sensor = WorkflowTaskDependencySensor(
+      databricks_host="https://your_workspace_url.cloud.databricks.com",
+      databricks_token=api_token_key,
+      dependency_job_id=job_id,
+      dependency_task_name="foo",
+      poke_interval=20,
+      timeout=60,
+      delta=timedelta(days=1)
+   )
+   sensor.execute()
+```
+
 #### Snowflake Operator
 
 run snowflake queries from the databricks environment 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4285,6 +4285,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requests-mock"
+version = "1.12.1"
+description = "Mock out responses from the requests package"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"},
+    {file = "requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563"},
+]
+
+[package.dependencies]
+requests = ">=2.22,<3"
+
+[package.extras]
+fixture = ["fixtures"]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 description = "A utility belt for advanced users of python-requests"
@@ -5474,4 +5491,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "5ac4fca6a235d709a992a8f6a34db72fddc1b532cc1a8beee278e63c41988cb7"
+content-hash = "b87bb4017bbdb0d96e0bf9f8475b7a262bd630d328011642ac07fc15885b7858"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ apache-airflow = "^2.7.3"
 snowflake = "^0.6.0"
 tableauserverclient = "^0.25"
 watchdog = "<4.0.0"
+requests-mock = "1.12.1"
 
 [tool.poetry.group.docs.dependencies]
 mdx-include = ">=1.4.1,<2.0.0"

--- a/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
+++ b/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
@@ -10,7 +10,7 @@ from brickflow_plugins.databricks.workflow_dependency_sensor import (
 
 
 class TestWorkflowTaskDependencySensor:
-    workspace_url = "https://42.cloud.databricks.com"
+    workspace_url = "https://42.cloud.databricks.com/"
     endpoint_url = f"{workspace_url}/api/2.1/jobs/runs/list"
     response = {
         "runs": [
@@ -49,6 +49,13 @@ class TestWorkflowTaskDependencySensor:
             return_value=1704063600000,
         )
 
+    @pytest.fixture(autouse=True)
+    def mock_get_job_id(self, mocker):
+        mocker.patch(
+            "brickflow_plugins.databricks.workflow_dependency_sensor.get_job_id",
+            return_value=1,
+        )
+
     @pytest.fixture(autouse=True, name="api")
     def mock_api(self):
         rm = RequestsMocker()
@@ -60,7 +67,7 @@ class TestWorkflowTaskDependencySensor:
             sensor = WorkflowTaskDependencySensor(
                 databricks_host=self.workspace_url,
                 databricks_token="token",
-                dependency_job_id=1,
+                dependency_job_name="job",
                 dependency_task_name="foo",
                 delta=timedelta(seconds=1),
                 timeout_seconds=1,
@@ -79,7 +86,7 @@ class TestWorkflowTaskDependencySensor:
             sensor = WorkflowTaskDependencySensor(
                 databricks_host=self.workspace_url,
                 databricks_token="token",
-                dependency_job_id=1,
+                dependency_job_name="job",
                 dependency_task_name="bar",
                 delta=timedelta(seconds=1),
                 timeout_seconds=1,

--- a/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
+++ b/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
@@ -10,7 +10,7 @@ from brickflow_plugins.databricks.workflow_dependency_sensor import (
 
 
 class TestWorkflowTaskDependencySensor:
-    workspace_url = "https://42.cloud.databricks.com/"
+    workspace_url = "https://42.cloud.databricks.com"
     endpoint_url = f"{workspace_url}/api/2.1/jobs/runs/list"
     response = {
         "runs": [

--- a/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
+++ b/tests/databricks_plugins/test_workflow_task_dependency_sensor.py
@@ -1,0 +1,96 @@
+from datetime import timedelta
+
+import pytest
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from brickflow_plugins.databricks.workflow_dependency_sensor import (
+    WorkflowTaskDependencySensor,
+    WorkflowDependencySensorTimeOutException,
+)
+
+
+class TestWorkflowTaskDependencySensor:
+    workspace_url = "https://42.cloud.databricks.com"
+    endpoint_url = f"{workspace_url}/api/2.1/jobs/runs/list"
+    response = {
+        "runs": [
+            {
+                "job_id": 1,
+                "run_id": 1,
+                "start_time": 1704063600000,
+                "state": {
+                    "result_state": "SUCCESS",
+                },
+                "tasks": [
+                    {
+                        "run_id": 100,
+                        "task_key": "foo",
+                        "state": {
+                            "result_state": "SUCCESS",
+                        },
+                    },
+                    {
+                        "run_id": 200,
+                        "task_key": "bar",
+                        "state": {
+                            "result_state": "FAILED",
+                        },
+                    },
+                ],
+            }
+        ]
+    }
+
+    @pytest.fixture(autouse=True)
+    def mock_get_execution_start_time_unix_milliseconds(self, mocker):
+        mocker.patch.object(
+            WorkflowTaskDependencySensor,
+            "get_execution_start_time_unix_milliseconds",
+            return_value=1704063600000,
+        )
+
+    @pytest.fixture(autouse=True, name="api")
+    def mock_api(self):
+        rm = RequestsMocker()
+        rm.get(self.endpoint_url, json=self.response, status_code=int(200))
+        yield rm
+
+    def test_sensor_success(self, caplog, api):
+        with api:
+            sensor = WorkflowTaskDependencySensor(
+                databricks_host=self.workspace_url,
+                databricks_token="token",
+                dependency_job_id=1,
+                dependency_task_name="foo",
+                delta=timedelta(seconds=1),
+                timeout_seconds=1,
+                poke_interval_seconds=1,
+            )
+
+            sensor.execute()
+
+            assert (
+                "Found the run_id '1' and 'foo' task with state: SUCCESS" in caplog.text
+            )
+            assert "Found a successful run: 1" in caplog.text
+
+    def test_sensor_failure(self, caplog, api):
+        with api:
+            sensor = WorkflowTaskDependencySensor(
+                databricks_host=self.workspace_url,
+                databricks_token="token",
+                dependency_job_id=1,
+                dependency_task_name="bar",
+                delta=timedelta(seconds=1),
+                timeout_seconds=1,
+                poke_interval_seconds=1,
+            )
+
+            with pytest.raises(WorkflowDependencySensorTimeOutException):
+                sensor.execute()
+                assert "The job has timed out..." in caplog.text
+                assert "Didn't find a successful task run yet..." in caplog.text
+                assert (
+                    "Found the run_id '1' and 'bar' task with state: FAILED"
+                    in caplog.text
+                )

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -1,0 +1,59 @@
+import pytest
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from pydantic import SecretStr
+
+from brickflow.engine.utils import get_job_id, ctx
+
+
+class TestUtils:
+    workspace_url = "https://42.cloud.databricks.com"
+    endpoint_url = f"{workspace_url}/api/2.1/jobs/list"
+
+    ctx.log.propagate = True
+
+    @pytest.fixture(autouse=True, name="api", scope="class")
+    def mock_api(self):
+        rm = RequestsMocker()
+        rm.register_uri(
+            method="GET",
+            url=self.endpoint_url,
+            response_list=[
+                {
+                    "json": {"jobs": [{"job_id": 1234, "settings": {"name": "foo"}}]},
+                    "status_code": int(200),
+                },
+                {
+                    "json": {"has_more": False},
+                    "status_code": int(200),
+                },
+                {
+                    "json": {},
+                    "status_code": int(404),
+                },
+            ],
+        )
+        yield rm
+
+    def test_get_job_id_success(self, api):
+        with api:
+            job_id = get_job_id(
+                job_name="foo",
+                workspace_url=self.workspace_url,
+                api_token=SecretStr("token"),
+            )
+        assert job_id == 1234
+
+    def test_get_job_id_failure(self, api):
+        with pytest.raises(ValueError):
+            with api:
+                get_job_id(
+                    job_name="bar", workspace_url=self.workspace_url, api_token="token"
+                )
+
+    def test_get_job_id_non_200(self, caplog, api):
+        with api:
+            get_job_id(
+                job_name="buz", workspace_url=self.workspace_url, api_token="token"
+            )
+        assert "Request returned a 404 code, with data '{}'" in caplog.text

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -39,21 +39,17 @@ class TestUtils:
         with api:
             job_id = get_job_id(
                 job_name="foo",
-                workspace_url=self.workspace_url,
-                api_token=SecretStr("token"),
+                host=self.workspace_url,
+                token=SecretStr("token"),
             )
         assert job_id == 1234
 
     def test_get_job_id_failure(self, api):
         with pytest.raises(ValueError):
             with api:
-                get_job_id(
-                    job_name="bar", workspace_url=self.workspace_url, api_token="token"
-                )
+                get_job_id(job_name="bar", host=self.workspace_url, token="token")
 
     def test_get_job_id_non_200(self, caplog, api):
         with api:
-            get_job_id(
-                job_name="buz", workspace_url=self.workspace_url, api_token="token"
-            )
-        assert "Request returned a 404 code, with data '{}'" in caplog.text
+            get_job_id(job_name="buz", host=self.workspace_url, token="token")
+        assert "An error occurred: request failed" in caplog.text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Leverage Databricks API to retrieve the state of the specific task within the workflow run. The code mostly inherits from the `WorkflowDependencySensor`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#109 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In many cases it's more benificial to put a dependency on a specific task within the workflow instead the workflow itself. It reduces the wait time of the downstream workflows.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests + workflow in Databricks with a success sensor and a failed sensor

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
