### PR TITLE
[fix] AutosysSensor: Handle the situations where `lastEndUTC` is empty or None

### DIFF
--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -387,9 +387,9 @@ class AutosysSensor(BaseSensorOperator):
         else:
             status = response.json()["status"][:2].upper()
 
-            last_end_timestamp = parse(response.json()["lastEndUTC"]).replace(
-                tzinfo=pytz.UTC
-            )
+            last_end_timestamp = None
+            if last_end_utc := response.json().get("lastEndUTC"):
+                last_end_timestamp = parse(last_end_utc).replace(tzinfo=pytz.UTC)
 
             time_delta = (
                 self.time_delta
@@ -397,10 +397,14 @@ class AutosysSensor(BaseSensorOperator):
                 else timedelta(**self.time_delta)
             )
 
-            execution_timestamp = parse(str(context["execution_date"]))
+            execution_timestamp = parse(context["execution_date"])
             run_timestamp = execution_timestamp - time_delta
 
-            if "SU" in status and last_end_timestamp >= run_timestamp:
+            if (
+                "SU" in status
+                and last_end_timestamp
+                and last_end_timestamp >= run_timestamp
+            ):
                 logging.info(
                     f"Last End: {last_end_timestamp}, Run Timestamp: {run_timestamp}"
                 )

--- a/tests/airflow_plugins/test_autosys.py
+++ b/tests/airflow_plugins/test_autosys.py
@@ -1,0 +1,72 @@
+import pytest
+from requests.exceptions import HTTPError
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from brickflow_plugins.airflow.operators.external_tasks import AutosysSensor
+
+
+class TestAutosysSensor:
+    @pytest.fixture(autouse=True, name="api", scope="class")
+    def mock_api(self):
+        rm = RequestsMocker()
+        rm.register_uri(
+            method="GET",
+            url="https://42.autosys.my-org.com/foo",
+            response_list=[
+                # Test 1: Success
+                {
+                    "json": {"status": "SU", "lastEndUTC": "2024-01-01T00:55:00Z"},
+                    "status_code": int(200),
+                },
+                # Test 2: Raise Error
+                {
+                    "json": {},
+                    "status_code": int(404),
+                },
+                # Test 3: Poke 4 times until success
+                {
+                    "json": {"status": "FA", "lastEndUTC": "2024-01-01T00:55:00Z"},
+                    "status_code": int(200),
+                },
+                {
+                    "json": {"status": "UNK", "lastEndUTC": None},
+                    "status_code": int(200),
+                },
+                {
+                    "json": {"status": "UNK", "lastEndUTC": ""},
+                    "status_code": int(200),
+                },
+                {
+                    "json": {"status": "SU", "lastEndUTC": "2024-01-01T01:55:00Z"},
+                    "status_code": int(200),
+                },
+            ],
+        )
+        yield rm
+
+    @pytest.fixture()
+    def sensor(self):
+        yield AutosysSensor(
+            task_id="test",
+            url="https://42.autosys.my-org.com/",
+            job_name="foo",
+            poke_interval=1,
+            time_delta={"hours": 1},
+        )
+
+    def test_success(self, api, caplog, sensor):
+        with api:
+            sensor.poke(context={"execution_date": "2024-01-01T01:00:00Z"})
+        assert caplog.text.count("Poking again") == 0
+        assert "Success criteria met. Exiting" in caplog.text
+
+    def test_non_200(self, api, sensor):
+        with pytest.raises(HTTPError):
+            with api:
+                sensor.poke(context={"execution_date": "2024-01-01T01:00:00Z"})
+
+    def test_poking(self, api, caplog, sensor):
+        with api:
+            sensor.poke(context={"execution_date": "2024-01-01T02:00:00Z"})
+        assert caplog.text.count("Poking again") == 3
+        assert "Success criteria met. Exiting" in caplog.text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle the situations where `lastEndUTC` data is None plus add tests to test the overall logic and error handling.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#112 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Operator is failing if `lastEndUTC` is empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A set of local tests has been implemented + used custom wheel in the workflow

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
