### PR TITLE
[fix] WorkflowTaskDependecySensor fails if the task execution has not started

### DIFF
--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -256,13 +256,19 @@ class WorkflowTaskDependencySensor(WorkflowDependencySensor):
                 for task in run.tasks:
                     if task.task_key == self.dependency_task_name:
                         task_state = task.state.result_state
-                        self.log.info(
-                            f"Found the run_id '{run.run_id}' and '{self.dependency_task_name}' "
-                            f"task with state: {task_state.value}"
-                        )
-                        if task_state.value == "SUCCESS":
-                            self.log.info(f"Found a successful run: {run.run_id}")
-                            return
+                        if task_state:
+                            self.log.info(
+                                f"Found the run_id '{run.run_id}' and '{self.dependency_task_name}' "
+                                f"task with state: {task_state.value}"
+                            )
+                            if task_state.value == "SUCCESS":
+                                self.log.info(f"Found a successful run: {run.run_id}")
+                                return
+                        else:
+                            self.log.info(
+                                f"Found the run_id '{run.run_id}' and '{self.dependency_task_name}' "
+                                f"but the task has not started yet..."
+                            )
 
             self.log.info("Didn't find a successful task run yet...")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check if `task_state` is not None, otherwise log and continue poking.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#122 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The sensor will otherwise fail if the task execution has not yet started (e.g. the task is in Pending state)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TDD

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
