### PR TITLE
TaskDependencySensor: do not fail if upstream failed / derive execution time from context

### DIFF
--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -7,6 +7,7 @@ from typing import Callable, Union
 import requests
 from airflow.models import Connection
 from airflow.sensors.base import BaseSensorOperator
+from airflow.exceptions import AirflowSensorTimeout
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests import HTTPError
@@ -217,6 +218,7 @@ class TaskDependencySensor(BaseSensorOperator):
         self.latest = latest
         self.poke_interval = poke_interval
         self._poke_count = 0
+        self._start_time = time.time()
 
     def get_execution_stats(self, execution_date: datetime):
         """Function to get the execution stats for task_id within a execution delta window
@@ -307,6 +309,9 @@ class TaskDependencySensor(BaseSensorOperator):
         self._poke_count = self._poke_count + 1
         log.info("Poking.. {0} round".format(str(self._poke_count)))
 
+        # Execution date is extracted from context and will be based on the task schedule, e.g.
+        # 0 0 1 ? * MON-SAT * -> 2024-01-01T01:00:00.000000+00:00
+        # This means that the relative delta between workflow execution and target Airflow DAG always stays the same.
         execution_date = parse(context["execution_date"])
         log.info(f"Execution date derived from context: {execution_date}")
 
@@ -345,6 +350,9 @@ class TaskDependencySensor(BaseSensorOperator):
                 time.sleep(self.poke_interval)
             elif status != "success":
                 time.sleep(self.poke_interval)
+
+            if (time.time() - self._start_time) > self.timeout:
+                raise AirflowSensorTimeout("The job has timed out")
         log.info(f"Upstream Dag {external_dag_id} is successful")
 
 

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -187,10 +187,6 @@ class AirflowScheduleHelper(DagSchedule):
         return o_task_status
 
 
-class TaskDependencySensorTimeOutException(TimeoutError):
-    pass
-
-
 class TaskDependencySensor(BaseSensorOperator):
     def __init__(
         self,
@@ -202,7 +198,6 @@ class TaskDependencySensor(BaseSensorOperator):
         execution_delta_json=None,
         latest=False,
         poke_interval=60,
-        timeout_seconds=3600,  # default: 1 hour
         *args,
         **kwargs,
     ):
@@ -221,9 +216,7 @@ class TaskDependencySensor(BaseSensorOperator):
         self.execution_delta_json = execution_delta_json
         self.latest = latest
         self.poke_interval = poke_interval
-        self.timeout_seconds = timeout_seconds
         self._poke_count = 0
-        self._start_time = time.time()
 
     def get_execution_stats(self, execution_date: datetime):
         """Function to get the execution stats for task_id within a execution delta window
@@ -352,9 +345,6 @@ class TaskDependencySensor(BaseSensorOperator):
                 time.sleep(self.poke_interval)
             elif status != "success":
                 time.sleep(self.poke_interval)
-
-            if (time.time() - self._start_time) > self.timeout_seconds:
-                raise TaskDependencySensorTimeOutException("The job has timed out")
         log.info(f"Upstream Dag {external_dag_id} is successful")
 
 

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -187,6 +187,10 @@ class AirflowScheduleHelper(DagSchedule):
         return o_task_status
 
 
+class TaskDependencySensorTimeOutException(TimeoutError):
+    pass
+
+
 class TaskDependencySensor(BaseSensorOperator):
     def __init__(
         self,
@@ -198,6 +202,7 @@ class TaskDependencySensor(BaseSensorOperator):
         execution_delta_json=None,
         latest=False,
         poke_interval=60,
+        timeout_seconds=3600,  # default: 1 hour
         *args,
         **kwargs,
     ):
@@ -216,9 +221,11 @@ class TaskDependencySensor(BaseSensorOperator):
         self.execution_delta_json = execution_delta_json
         self.latest = latest
         self.poke_interval = poke_interval
+        self.timeout_seconds = timeout_seconds
         self._poke_count = 0
+        self._start_time = time.time()
 
-    def get_execution_stats(self):
+    def get_execution_stats(self, execution_date: datetime):
         """Function to get the execution stats for task_id within a execution delta window
 
         Returns:
@@ -231,7 +238,7 @@ class TaskDependencySensor(BaseSensorOperator):
         external_dag_id = self.external_dag_id
         external_task_id = self.external_task_id
         execution_delta = self.execution_delta
-        execution_window_tz = (datetime.now() + execution_delta).strftime(
+        execution_window_tz = (execution_date + execution_delta).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
         headers = {
@@ -257,17 +264,20 @@ class TaskDependencySensor(BaseSensorOperator):
                 + f"/dagRuns?execution_date_gte={execution_window_tz}"
             )
         log.info(f"URL to poke for dag runs {url}")
-        response = requests.request("GET", url, headers=headers)
-        if response.status_code == 401:
-            raise Exception(
-                f"No Runs found for {external_dag_id} dag after {execution_window_tz}, Please check upstream dag"
-            )
+        response = requests.request("GET", url, headers=headers, verify=False)
         response.raise_for_status()
-        list_of_dictionaries = response.json()
+
         list_of_dictionaries = response.json()["dag_runs"]
         list_of_dictionaries = sorted(
             list_of_dictionaries, key=lambda k: k["execution_date"], reverse=True
         )
+
+        if len(list_of_dictionaries) == 0:
+            log.info(
+                f"No Runs found for {external_dag_id} dag after {execution_window_tz}, please check upstream dag"
+            )
+            return "none"
+
         if af_version.startswith("1."):
             # For airflow 1.X Execution date is needed to check the status of the task
             dag_run_id = list_of_dictionaries[0]["execution_date"]
@@ -294,7 +304,7 @@ class TaskDependencySensor(BaseSensorOperator):
                 + f"/dagRuns/{dag_run_id}/taskInstances/{external_task_id}"
             )
         log.info(f"Pinging airflow API {task_url} for task status ")
-        task_response = requests.request("GET", task_url, headers=headers)
+        task_response = requests.request("GET", task_url, headers=headers, verify=False)
         task_response.raise_for_status()
         task_state = task_response.json()["state"]
         return task_state
@@ -302,9 +312,13 @@ class TaskDependencySensor(BaseSensorOperator):
     def poke(self, context):
         log.info(f"executing poke.. {self._poke_count}")
         self._poke_count = self._poke_count + 1
-        logging.info("Poking.. {0} round".format(str(self._poke_count)))
-        task_status = self.get_execution_stats()
-        log.info(f"task_status= {task_status}")
+        log.info("Poking.. {0} round".format(str(self._poke_count)))
+
+        execution_date = parse(context["execution_date"])
+        log.info(f"Execution date derived from context: {execution_date}")
+
+        task_status = self.get_execution_stats(execution_date=execution_date)
+        log.info(f"task_status={task_status}")
         return task_status
 
     def execute(self, context):
@@ -321,9 +335,9 @@ class TaskDependencySensor(BaseSensorOperator):
         external_dag_id = self.external_dag_id
         external_task_id = self.external_task_id
         execution_delta = self.execution_delta
-        execution_window_tz = (datetime.now() + execution_delta).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        execution_window_tz = (
+            parse(context["execution_date"]) + execution_delta
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
         log.info(
             f"Executing TaskDependency Sensor Operator to check successful run for {external_dag_id} dag, task {external_task_id} after {execution_window_tz} "
         )
@@ -331,12 +345,16 @@ class TaskDependencySensor(BaseSensorOperator):
         while status not in allowed_states:
             status = self.poke(context)
             if status == "failed":
+                # Log the fact that upstream failed, however do not fail the task and continue poking until timeout
                 log.error(
                     f"Upstream dag {external_dag_id} failed at {external_task_id} task "
                 )
-                raise Exception("Upstream Dag Failed")
+                time.sleep(self.poke_interval)
             elif status != "success":
                 time.sleep(self.poke_interval)
+
+            if (time.time() - self._start_time) > self.timeout_seconds:
+                raise TaskDependencySensorTimeOutException("The job has timed out")
         log.info(f"Upstream Dag {external_dag_id} is successful")
 
 

--- a/tests/airflow_plugins/test_task_dependency.py
+++ b/tests/airflow_plugins/test_task_dependency.py
@@ -1,0 +1,130 @@
+from datetime import timedelta
+
+import pytest
+from requests.exceptions import HTTPError
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from brickflow_plugins.airflow.operators.external_tasks import (
+    TaskDependencySensor,
+    AirflowProxyOktaClusterAuth,
+    log,
+    AirflowSensorTimeout,
+)
+
+BASE_URL = "https://42.airflow.my-org.com/foo"
+
+
+class TestTaskDependencySensor:
+    log.propagate = True
+
+    @pytest.fixture(autouse=True, name="api", scope="class")
+    def mock_api(self):
+        """
+        End-to-end test scenario for Airflow v2 API
+        """
+        rm = RequestsMocker()
+        # DAG Run Endpoint
+        rm.register_uri(
+            method="GET",
+            url=f"{BASE_URL}/api/v1/dags/test-dag/dagRuns?execution_date_gte=2024-01-01T00:00:00Z",
+            response_list=[
+                # Test 1: No Run
+                {"json": {"dag_runs": [], "total_entries": 0}, "status_code": int(200)},
+                # Test 2: Run Exists
+                {
+                    "json": {
+                        "dag_runs": [
+                            {
+                                "conf": {},
+                                "dag_id": "test-dag",
+                                "dag_run_id": "manual__2024-01-01T01:00:00.000000+00:00",
+                                "end_date": "2024-01-01T01:10:00.000000+00:00",
+                                "execution_date": "2024-01-01T01:00:00.000000+00:00",
+                                "external_trigger": True,
+                                "logical_date": "2024-01-01T01:00:00.000000+00:00",
+                                "start_date": "2024-01-01T01:00:00.000000+00:00",
+                                "state": "success",
+                            },
+                        ],
+                        "total_entries": 1,
+                    },
+                    "status_code": int(200),
+                },
+                # Test 2: No Run
+            ],
+        )
+        # Task Instance Endpoint
+        rm.register_uri(
+            method="GET",
+            url=(
+                f"{BASE_URL}"
+                f"/api/v1/dags/test-dag/dagRuns/manual__2024-01-01T01:00:00.000000+00:00/taskInstances/test-task"
+            ),
+            response_list=[
+                {"json": {"state": "running"}, "status_code": int(200)},
+                {"json": {"state": "failed"}, "status_code": int(200)},
+                {"json": {"state": "success"}, "status_code": int(200)},
+            ],
+        )
+        yield rm
+
+    @pytest.fixture()
+    def sensor(self, mocker):
+        auth_mock = mocker.MagicMock(spec=AirflowProxyOktaClusterAuth)
+        auth_mock.get_access_token.return_value = "foo"
+        auth_mock.get_airflow_api_url.return_value = BASE_URL
+        auth_mock.get_version.return_value = "2.0.2"
+
+        yield TaskDependencySensor(
+            external_dag_id="test-dag",
+            external_task_id="test-task",
+            allowed_states=["success"],
+            execution_delta=timedelta(**{"hours": -3}),
+            airflow_auth=auth_mock,
+            task_id="foo",
+            poke_interval=1,
+        )
+
+    def test_api_airflow_v2(self, api, caplog, sensor):
+        # Scenario
+        # Airflow API poked 4 times
+        # 1. No Run
+        # 2. Run Exists - Task is in Running State
+        # 3. Run Exists - Task is in Failed State
+        # 4. Run Exists - Task is in Success State
+        with api:
+            sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
+
+        assert (
+            "No Runs found for test-dag dag after 2024-01-01T00:00:00Z, please check upstream dag"
+            in caplog.text
+        )
+        assert "task_status=running" in caplog.text
+        assert "task_status=failed" in caplog.text
+        assert "task_status=success" in caplog.text
+        assert "Poking.. 4 round" in caplog.text
+
+    def test_non_200(self, sensor):
+        rm = RequestsMocker()
+        rm.get(
+            f"{BASE_URL}/api/v1/dags/test-dag/dagRuns?execution_date_gte=2024-01-01T00:00:00Z",
+            status_code=404,
+        )
+
+        with pytest.raises(HTTPError):
+            with rm:
+                sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
+
+    def test_timeout(self, sensor):
+        sensor.timeout = 1
+
+        rm = RequestsMocker()
+        rm.get(
+            url=f"{BASE_URL}/api/v1/dags/test-dag/dagRuns?execution_date_gte=2024-01-01T00:00:00Z",
+            status_code=200,
+            json={"dag_runs": [], "total_entries": 0},
+        )
+
+        with pytest.raises(AirflowSensorTimeout):
+            with rm:
+                sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These changes are in line with the reasoning that's described in #101.
1. Make sensor results repeatable if workflow is restarted by using the `execution_date` which is derived from Brickflow context and not the current time. This ensures that relative delta between the workflow run (based on it's schedule) and the upstream DAG run always stays the same.
2. Sensor will always poke upstream, unless timeout is reached. This ensure that if upstream is failed or running, or in some other state, the sensor will continue waiting for the `success` (by default)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#101 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improve sensor stability and simplify workflow reruns.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests + this code had been overriding the original sensor and running in production pipelines

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
