### PR TITLE
[FEATURE] Support remote workspace for RunJobTask

### DIFF
--- a/brickflow/engine/task.py
+++ b/brickflow/engine/task.py
@@ -763,7 +763,6 @@ class Task:
     ensure_brickflow_plugins: bool = False
     health: Optional[List[JobsTasksHealthRules]] = None
     if_else_outcome: Optional[Dict[Union[str, str], str]] = None
-    _run_job_override: bool = False  # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
 
     def __post_init__(self) -> None:
         self.is_valid_task_signature()
@@ -1009,19 +1008,6 @@ class Task:
 
         _ilog.info("Executing task... %s", self.name)
         _ilog.info("%s", pretty_print_function_source(self.name, self.task_func))
-
-        # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
-        # See `brickflow.engine.workflow.Workflow._add_task` for more details
-        if self.task_type == TaskType.BRICKFLOW_TASK and self._run_job_override is True:
-            from brickflow_plugins.databricks.run_job import RunJobInRemoteWorkspace
-
-            tf = self.task_func()
-            RunJobInRemoteWorkspace(
-                databricks_host=tf.host,
-                databricks_token=tf.token,
-                job_name=tf.job_name,
-            ).execute()  # TODO: this does not work yet
-        # NOTE: END REMOTE WORKSPACE RUN JOB OVERRIDE
 
         brickflow_execution_hook = get_brickflow_tasks_hook()
 

--- a/brickflow/engine/task.py
+++ b/brickflow/engine/task.py
@@ -763,6 +763,7 @@ class Task:
     ensure_brickflow_plugins: bool = False
     health: Optional[List[JobsTasksHealthRules]] = None
     if_else_outcome: Optional[Dict[Union[str, str], str]] = None
+    _run_job_override: bool = False  # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
 
     def __post_init__(self) -> None:
         self.is_valid_task_signature()
@@ -1008,6 +1009,19 @@ class Task:
 
         _ilog.info("Executing task... %s", self.name)
         _ilog.info("%s", pretty_print_function_source(self.name, self.task_func))
+
+        # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
+        # See `brickflow.engine.workflow.Workflow._add_task` for more details
+        if self.task_type == TaskType.BRICKFLOW_TASK and self._run_job_override is True:
+            from brickflow_plugins.databricks.run_job import RunJobInRemoteWorkspace
+
+            tf = self.task_func()
+            RunJobInRemoteWorkspace(
+                databricks_host=tf.host,
+                databricks_token=tf.token,
+                job_name=tf.job_name,
+            ).execute()  # TODO: this does not work yet
+        # NOTE: END REMOTE WORKSPACE RUN JOB OVERRIDE
 
         brickflow_execution_hook = get_brickflow_tasks_hook()
 

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -327,13 +327,18 @@ class Workflow:
         else:
             ensure_plugins = ensure_brickflow_plugins
 
-        # NOTE: This is a temporary override for the RunJobTask because Databricks does not natively support
+        # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
+        # This is a temporary override for the RunJobTask because Databricks does not natively support
         # triggering the job run in the remote workspace. By default, Databricks SDK derives the workspace URL
         # from the runtime, and hence it is not required by the RunJobTask. The assumption is that if `host` parameter
         # is set, user wants to trigger a remote job, in this case we set the task type to BRICKFLOW_TASK to
-        # enforce notebook type execution.
+        # enforce notebook type execution and `run_job_override`  to override the class that will be executed in
+        # brickflow.engine.task.Task.execute
+        run_job_override = False
         if task_type == TaskType.RUN_JOB_TASK and f().host:
             task_type = TaskType.BRICKFLOW_TASK
+            run_job_override = True
+        # NOTE: END REMOTE WORKSPACE RUN JOB OVERRIDE
 
         self.tasks[task_id] = Task(
             task_id=task_id,
@@ -349,6 +354,7 @@ class Workflow:
             custom_execute_callback=custom_execute_callback,
             ensure_brickflow_plugins=ensure_plugins,
             if_else_outcome=if_else_outcome,
+            _run_job_override=run_job_override,  # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
         )
 
         # attempt to create task object before adding to graph

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -332,12 +332,23 @@ class Workflow:
         # triggering the job run in the remote workspace. By default, Databricks SDK derives the workspace URL
         # from the runtime, and hence it is not required by the RunJobTask. The assumption is that if `host` parameter
         # is set, user wants to trigger a remote job, in this case we set the task type to BRICKFLOW_TASK to
-        # enforce notebook type execution and `run_job_override`  to override the class that will be executed in
-        # brickflow.engine.task.Task.execute
-        run_job_override = False
-        if task_type == TaskType.RUN_JOB_TASK and f().host:
-            task_type = TaskType.BRICKFLOW_TASK
-            run_job_override = True
+        # enforce notebook type execution and replacing the original callable function with the RunJobInRemoteWorkspace
+        if task_type == TaskType.RUN_JOB_TASK:
+            func = f()
+            if func.host:
+                from brickflow_plugins.databricks.run_job import RunJobInRemoteWorkspace
+
+                task_type = TaskType.BRICKFLOW_TASK
+
+                def run_job_func() -> Callable:
+                    # Using parameter values from the original RunJobTask
+                    return RunJobInRemoteWorkspace(
+                        job_name=func.job_name,
+                        databricks_host=func.host,
+                        databricks_token=func.token,
+                    ).execute()
+
+                f = run_job_func
         # NOTE: END REMOTE WORKSPACE RUN JOB OVERRIDE
 
         self.tasks[task_id] = Task(
@@ -354,7 +365,6 @@ class Workflow:
             custom_execute_callback=custom_execute_callback,
             ensure_brickflow_plugins=ensure_plugins,
             if_else_outcome=if_else_outcome,
-            _run_job_override=run_job_override,  # NOTE: REMOTE WORKSPACE RUN JOB OVERRIDE
         )
 
         # attempt to create task object before adding to graph

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -327,6 +327,15 @@ class Workflow:
         else:
             ensure_plugins = ensure_brickflow_plugins
 
+        # NOTE: This is a temporary override for the RunJobTask because Databricks does not natively support
+        # triggering the job run in the remote workspace. By default, Databricks SDK derives the workspace URL
+        # from the runtime, and hence it is not required by the RunJobTask. The assumption is that if `host` parameter
+        # is set, user wants to trigger a remote job, in this case we set the task type to BRICKFLOW_TASK to
+        # enforce notebook type execution.
+        if task_type == TaskType.RUN_JOB_TASK:
+            if f().host:
+                task_type = TaskType.BRICKFLOW_TASK
+
         self.tasks[task_id] = Task(
             task_id=task_id,
             task_func=f,

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -332,9 +332,8 @@ class Workflow:
         # from the runtime, and hence it is not required by the RunJobTask. The assumption is that if `host` parameter
         # is set, user wants to trigger a remote job, in this case we set the task type to BRICKFLOW_TASK to
         # enforce notebook type execution.
-        if task_type == TaskType.RUN_JOB_TASK:
-            if f().host:
-                task_type = TaskType.BRICKFLOW_TASK
+        if task_type == TaskType.RUN_JOB_TASK and f().host:
+            task_type = TaskType.BRICKFLOW_TASK
 
         self.tasks[task_id] = Task(
             task_id=task_id,

--- a/brickflow_plugins/databricks/run_job.py
+++ b/brickflow_plugins/databricks/run_job.py
@@ -49,5 +49,6 @@ class RunJobInRemoteWorkspace:
             token=self.databricks_token,
             job_name=self.job_name,
         )
+        # TODO: add support for passing parameters to the remote job
         run = self._workspace_obj.jobs.run_now(job_id)
         ctx.log.info("Job run status: %s", run.response)

--- a/brickflow_plugins/databricks/run_job.py
+++ b/brickflow_plugins/databricks/run_job.py
@@ -1,0 +1,53 @@
+from typing import Union
+from pydantic import SecretStr
+
+from databricks.sdk import WorkspaceClient
+from brickflow.context import ctx
+from brickflow.engine.utils import get_job_id
+
+
+class RunJobInRemoteWorkspace:
+    """
+    Currently Databricks does not natively support running a job in a remote workspace via the RunJobTask.
+    This plugin adds this functionality. However, it aims to be a temporary solution until Databricks adds this
+    functionality natively.
+    The plugin does not support neither passing the parameters to the remote job, nor waiting for the job to finish.
+
+    Examples
+    --------
+        service_principle_pat = ctx.dbutils.secrets.get("scope", "service_principle_id")
+        WorkflowDependencySensor(
+            databricks_host=https://your_workspace_url.cloud.databricks.com,
+            databricks_token=service_principle_pat,
+            job_name="foo",
+        )
+        In the above snippet Databricks secrets are used as a secure service to store the databricks token.
+        If you get your token from another secret management service, like AWS Secrets Manager, GCP Secret Manager
+        or Azure Key Vault, just pass it in the databricks_token argument.
+    """
+
+    def __init__(
+        self,
+        databricks_host: str,
+        databricks_token: Union[str, SecretStr],
+        job_name: str,
+    ):
+        self.databricks_host = databricks_host
+        self.databricks_token = (
+            databricks_token
+            if isinstance(databricks_token, SecretStr)
+            else SecretStr(databricks_token)
+        )
+        self.job_name = job_name
+        self._workspace_obj = WorkspaceClient(
+            host=self.databricks_host, token=self.databricks_token.get_secret_value()
+        )
+
+    def execute(self):
+        job_id = get_job_id(
+            host=self.databricks_host,
+            token=self.databricks_token,
+            job_name=self.job_name,
+        )
+        run = self._workspace_obj.jobs.run_now(job_id)
+        ctx.log.info("Job run status: %s", run.response)

--- a/brickflow_plugins/databricks/run_job.py
+++ b/brickflow_plugins/databricks/run_job.py
@@ -50,5 +50,6 @@ class RunJobInRemoteWorkspace:
             job_name=self.job_name,
         )
         # TODO: add support for passing parameters to the remote job
+        # TODO: wait for the job to finish
         run = self._workspace_obj.jobs.run_now(job_id)
         ctx.log.info("Job run status: %s", run.response)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -280,6 +280,12 @@ RunJobTask class can accept the following as inputs:<br />
 &emsp;<b>host [Optional]</b>: The URL of the Databricks workspace.<br />
 &emsp;<b>token [Optional]</b>: The Databricks API token.
 
+!!! important
+
+    Databricks does not natively support triggering the job run in the remote workspace. Only set `host` and `token`
+    parameters when remote trigger is required, it will envoke RunJobInRemoteWorkspace plugin which will transparently 
+    substitute the native execution. No extra action will be required from the user.
+
 
 #### JAR Task
 

--- a/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
@@ -123,6 +123,36 @@ targets:
               retry_on_timeout: null
               task_key: run_job_task_a
               timeout_seconds: null
+            - "depends_on":
+              - "outcome": null
+                "task_key": "notebook_task_a"
+              "email_notifications": {}
+              "existing_cluster_id": "existing_cluster_id"
+              "libraries": []
+              "max_retries": null
+              "min_retry_interval_millis": null
+              "notebook_task":
+                "base_parameters":
+                  "all_tasks1": "test"
+                  "all_tasks3": "123"
+                  "brickflow_env": "dev"
+                  "brickflow_internal_only_run_tasks": ""
+                  "brickflow_internal_task_name": "{{task_key}}"
+                  "brickflow_internal_workflow_name": "test"
+                  "brickflow_internal_workflow_prefix": ""
+                  "brickflow_internal_workflow_suffix": ""
+                  "brickflow_job_id": "{{job_id}}"
+                  "brickflow_parent_run_id": "{{parent_run_id}}"
+                  "brickflow_run_id": "{{run_id}}"
+                  "brickflow_start_date": "{{start_date}}"
+                  "brickflow_start_time": "{{start_time}}"
+                  "brickflow_task_key": "{{task_key}}"
+                  "brickflow_task_retry_count": "{{task_retry_count}}"
+                "notebook_path": "some/path/to/root/test_databricks_bundle.py"
+                "source": "GIT"
+              "retry_on_timeout": null
+              "task_key": "run_job_task_b"
+              "timeout_seconds": null
             - depends_on: []
               email_notifications: {}
               existing_cluster_id: existing_cluster_id

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
@@ -123,6 +123,36 @@ targets:
               retry_on_timeout: null
               task_key: run_job_task_a
               timeout_seconds: null
+            - "depends_on":
+              - "outcome": null
+                "task_key": "notebook_task_a"
+              "email_notifications": {}
+              "existing_cluster_id": "existing_cluster_id"
+              "libraries": []
+              "max_retries": null
+              "min_retry_interval_millis": null
+              "notebook_task":
+                "base_parameters":
+                  "all_tasks1": "test"
+                  "all_tasks3": "123"
+                  "brickflow_env": "dev"
+                  "brickflow_internal_only_run_tasks": ""
+                  "brickflow_internal_task_name": "{{task_key}}"
+                  "brickflow_internal_workflow_name": "test"
+                  "brickflow_internal_workflow_prefix": ""
+                  "brickflow_internal_workflow_suffix": ""
+                  "brickflow_job_id": "{{job_id}}"
+                  "brickflow_parent_run_id": "{{parent_run_id}}"
+                  "brickflow_run_id": "{{run_id}}"
+                  "brickflow_start_date": "{{start_date}}"
+                  "brickflow_start_time": "{{start_time}}"
+                  "brickflow_task_key": "{{task_key}}"
+                  "brickflow_task_retry_count": "{{task_retry_count}}"
+                "notebook_path": "test_databricks_bundle.py"
+                "source": "GIT"
+              "retry_on_timeout": null
+              "task_key": "run_job_task_b"
+              "timeout_seconds": null
             - depends_on: []
               email_notifications: {}
               existing_cluster_id: existing_cluster_id

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
@@ -197,6 +197,39 @@ targets:
               retry_on_timeout: null
               task_key: run_job_task_a
               timeout_seconds: null
+            - "depends_on":
+              - "outcome": null
+                "task_key": "notebook_task_a"
+              "email_notifications": {}
+              "existing_cluster_id": "existing_cluster_id"
+              "libraries":
+              - "pypi":
+                  "package": "brickflows==0.1.0"
+                  "repo": null
+              "max_retries": null
+              "min_retry_interval_millis": null
+              "notebook_task":
+                "base_parameters":
+                  "all_tasks1": "test"
+                  "all_tasks3": "123"
+                  "brickflow_env": "dev"
+                  "brickflow_internal_only_run_tasks": ""
+                  "brickflow_internal_task_name": "{{task_key}}"
+                  "brickflow_internal_workflow_name": "test"
+                  "brickflow_internal_workflow_prefix": ""
+                  "brickflow_internal_workflow_suffix": ""
+                  "brickflow_job_id": "{{job_id}}"
+                  "brickflow_parent_run_id": "{{parent_run_id}}"
+                  "brickflow_run_id": "{{run_id}}"
+                  "brickflow_start_date": "{{start_date}}"
+                  "brickflow_start_time": "{{start_time}}"
+                  "brickflow_task_key": "{{task_key}}"
+                  "brickflow_task_retry_count": "{{task_retry_count}}"
+                "notebook_path": "test_databricks_bundle.py"
+                "source": "GIT"
+              "retry_on_timeout": null
+              "task_key": "run_job_task_b"
+              "timeout_seconds": null
             - depends_on: []
               email_notifications: {}
               existing_cluster_id: existing_cluster_id

--- a/tests/codegen/expected_bundles/local_bundle.yml
+++ b/tests/codegen/expected_bundles/local_bundle.yml
@@ -119,6 +119,36 @@ targets:
               retry_on_timeout: null
               task_key: run_job_task_a
               timeout_seconds: null
+            - "depends_on":
+              - "outcome": null
+                "task_key": "notebook_task_a"
+              "email_notifications": {}
+              "existing_cluster_id": "existing_cluster_id"
+              "libraries": []
+              "max_retries": null
+              "min_retry_interval_millis": null
+              "notebook_task":
+                "base_parameters":
+                  "all_tasks1": "test"
+                  "all_tasks3": "123"
+                  "brickflow_env": "local"
+                  "brickflow_internal_only_run_tasks": ""
+                  "brickflow_internal_task_name": "{{task_key}}"
+                  "brickflow_internal_workflow_name": "test"
+                  "brickflow_internal_workflow_prefix": ""
+                  "brickflow_internal_workflow_suffix": ""
+                  "brickflow_job_id": "{{job_id}}"
+                  "brickflow_parent_run_id": "{{parent_run_id}}"
+                  "brickflow_run_id": "{{run_id}}"
+                  "brickflow_start_date": "{{start_date}}"
+                  "brickflow_start_time": "{{start_time}}"
+                  "brickflow_task_key": "{{task_key}}"
+                  "brickflow_task_retry_count": "{{task_retry_count}}"
+                "notebook_path": "test_databricks_bundle.py"
+                "source": "WORKSPACE"
+              "retry_on_timeout": null
+              "task_key": "run_job_task_b"
+              "timeout_seconds": null
             - depends_on: []
               email_notifications: {}
               existing_cluster_id: existing_cluster_id

--- a/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
+++ b/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
@@ -120,6 +120,36 @@ targets:
               retry_on_timeout: null
               task_key: run_job_task_a
               timeout_seconds: null
+            - "depends_on":
+              - "outcome": null
+                "task_key": "notebook_task_a"
+              "email_notifications": {}
+              "existing_cluster_id": "existing_cluster_id"
+              "libraries": []
+              "max_retries": null
+              "min_retry_interval_millis": null
+              "notebook_task":
+                "base_parameters":
+                  "all_tasks1": "test"
+                  "all_tasks3": "123"
+                  "brickflow_env": "local"
+                  "brickflow_internal_only_run_tasks": ""
+                  "brickflow_internal_task_name": "{{task_key}}"
+                  "brickflow_internal_workflow_name": "test"
+                  "brickflow_internal_workflow_prefix": ""
+                  "brickflow_internal_workflow_suffix": ""
+                  "brickflow_job_id": "{{job_id}}"
+                  "brickflow_parent_run_id": "{{parent_run_id}}"
+                  "brickflow_run_id": "{{run_id}}"
+                  "brickflow_start_date": "{{start_date}}"
+                  "brickflow_start_time": "{{start_time}}"
+                  "brickflow_task_key": "{{task_key}}"
+                  "brickflow_task_retry_count": "{{task_retry_count}}"
+                "notebook_path": "test_databricks_bundle.py"
+                "source": "WORKSPACE"
+              "retry_on_timeout": null
+              "task_key": "run_job_task_b"
+              "timeout_seconds": null
             - depends_on: []
               email_notifications: {}
               existing_cluster_id: existing_cluster_id

--- a/tests/codegen/sample_workflow.py
+++ b/tests/codegen/sample_workflow.py
@@ -81,6 +81,13 @@ def run_job_task_a():
     return RunJobTask(job_name="dev_object_raw_to_cleansed")  # type: ignore
 
 
+@wf.run_job_task(
+    depends_on=notebook_task_a,
+)
+def run_job_task_b():
+    return RunJobTask(job_name="dev_object_raw_to_cleansed", host="https://foo.cloud.databricks.com")  # type: ignore
+
+
 @wf.sql_task
 def sample_sql_task_query() -> any:
     return SqlTask(

--- a/tests/codegen/test_databricks_bundle.py
+++ b/tests/codegen/test_databricks_bundle.py
@@ -28,7 +28,10 @@ from brickflow.codegen.databricks_bundle import (
 )
 from brickflow.engine.project import Stage, Project
 from brickflow.engine.task import NotebookTask
-from tests.codegen.sample_workflow import wf
+
+# `get_job_id` is being called during workflow init, hence the patch
+with patch("brickflow.engine.task.get_job_id", return_value=12345678901234.0) as p:
+    from tests.codegen.sample_workflow import wf
 
 # BUNDLE_FILE_NAME = str(Path(__file__).parent / f"bundle.yml")
 BUNDLE_FILE_NAME = "bundle.yml"

--- a/tests/databricks_plugins/test_run_job.py
+++ b/tests/databricks_plugins/test_run_job.py
@@ -1,0 +1,38 @@
+import re
+
+import pytest
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from brickflow.engine.utils import ctx
+from brickflow_plugins.databricks.run_job import RunJobInRemoteWorkspace
+
+
+class TestRunJob:
+    workspace_url = "https://42.cloud.databricks.com"
+    endpoint_url = f"{workspace_url}/api/.*/jobs/run-now"
+    response = {"run_id": 37, "number_in_job": 42}
+
+    ctx.log.propagate = True
+
+    @pytest.fixture(autouse=True)
+    def mock_get_job_id(self, mocker):
+        mocker.patch(
+            "brickflow_plugins.databricks.run_job.get_job_id",
+            return_value=1,
+        )
+
+    @pytest.fixture(autouse=True, name="api")
+    def mock_api(self):
+        rm = RequestsMocker()
+        rm.post(re.compile(self.endpoint_url), json=self.response, status_code=int(200))
+        yield rm
+
+    def test_run_job(self, api, caplog):
+        with api:
+            RunJobInRemoteWorkspace(
+                databricks_host=self.workspace_url,
+                databricks_token="token",
+                job_name="foo",
+            ).execute()
+
+        assert "RunNowResponse(number_in_job=42, run_id=37)" in caplog.text

--- a/tests/engine/sample_workflow.py
+++ b/tests/engine/sample_workflow.py
@@ -4,6 +4,7 @@ from brickflow.engine.task import (
     TaskType,
     TaskResponse,
     DLTPipeline,
+    RunJobTask,
 )
 from brickflow.engine.workflow import Workflow, WorkflowPermissions, User
 
@@ -102,3 +103,8 @@ def task_function_4():
 )
 def custom_python_task_push():
     pass
+
+
+@wf.run_job_task()
+def run_job_task():
+    return RunJobTask(job_name="foo", host="https://foo.cloud.databricks.com")

--- a/tests/engine/test_project.py
+++ b/tests/engine/test_project.py
@@ -15,7 +15,9 @@ from brickflow.engine.project import (
     ExecuteError,
 )
 from brickflow.engine.workflow import Workflow
-from tests.engine.sample_workflow import wf, task_function
+
+with patch("brickflow.engine.task.get_job_id", return_value=12345678901234):
+    from tests.engine.sample_workflow import wf, task_function
 
 
 def side_effect(a, _):  # noqa

--- a/tests/engine/test_utils.py
+++ b/tests/engine/test_utils.py
@@ -1,3 +1,4 @@
+import re
 import pathlib
 import pytest
 from requests_mock.mocker import Mocker as RequestsMocker
@@ -9,7 +10,7 @@ from brickflow.engine.utils import get_job_id, ctx, get_bf_project_root
 
 class TestUtils:
     workspace_url = "https://42.cloud.databricks.com"
-    endpoint_url = f"{workspace_url}/api/2.1/jobs/list"
+    endpoint_url = f"{workspace_url}/api/.*/jobs/list"
 
     ctx.log.propagate = True
 
@@ -18,7 +19,7 @@ class TestUtils:
         rm = RequestsMocker()
         rm.register_uri(
             method="GET",
-            url=self.endpoint_url,
+            url=re.compile(self.endpoint_url),
             response_list=[
                 {
                     "json": {"jobs": [{"job_id": 1234, "settings": {"name": "foo"}}]},

--- a/tests/engine/test_workflow.py
+++ b/tests/engine/test_workflow.py
@@ -1,5 +1,7 @@
+from unittest.mock import patch
 import pytest
 
+import brickflow_plugins.databricks.run_job
 from brickflow.engine.compute import Cluster, DuplicateClustersDefinitionError
 from brickflow.engine.task import (
     Task,
@@ -18,7 +20,10 @@ from brickflow.engine.workflow import (
     NoWorkflowComputeError,
     WorkflowConfigError,
 )
-from tests.engine.sample_workflow import wf, task_function
+
+# `get_job_id` is being called during workflow init, hence the patch
+with patch("brickflow.engine.task.get_job_id", return_value=12345678901234):
+    from tests.engine.sample_workflow import wf, task_function, run_job_task
 
 
 class TestWorkflow:
@@ -155,7 +160,7 @@ class TestWorkflow:
             wf.task("hello world")
 
     def test_get_tasks(self):
-        assert len(wf.tasks) == 10
+        assert len(wf.tasks) == 11
 
     def test_task_iter(self):
         arr = []
@@ -163,7 +168,7 @@ class TestWorkflow:
             assert isinstance(t, Task)
             assert callable(t.task_func)
             arr.append(t)
-        assert len(arr) == 10, print([t.name for t in arr])
+        assert len(arr) == 11, print([t.name for t in arr])
 
     def test_permissions(self):
         assert wf.permissions.to_access_controls() == [
@@ -236,7 +241,7 @@ class TestWorkflow:
         from tests.engine.sample_workflow_2 import wf as wf1
 
         assert len(wf1.graph.nodes) == 2
-        assert len(wf.graph.nodes) == 11
+        assert len(wf.graph.nodes) == 12
 
     def test_schedule_run_status_workflow(self):
         this_wf = Workflow("test", clusters=[Cluster("name", "spark", "vm-node")])
@@ -265,3 +270,15 @@ class TestWorkflow:
         assert "schedule_pause_status must be one of ['PAUSED', 'UNPAUSED']" == str(
             excinfo.value
         )
+
+    def test_add_task_for_run_job_task(self, mocker):
+        with mocker.patch("brickflow_plugins.databricks.run_job.WorkspaceClient"):
+            with mocker.patch.object(
+                brickflow_plugins.databricks.run_job.RunJobInRemoteWorkspace,
+                "execute",
+                return_value="success",
+            ):
+                t = wf.get_task(run_job_task.__name__)
+                assert t.name == run_job_task.__name__
+                assert t.task_func.__name__ == "run_job_func"
+                assert t.task_func() == "success"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Databricks does not natively support riggering the job run in the remote workspace. This feature implements the logic that either creates a native RunJobTask or leverages the new RunJobInRemoteWorkspace plugin to execute both local and remote workspace job runs. The functionality does not require any additional parameters, and leverage the `host` parameter of the RunJobTask with the assumtion that if host is provided, user wants remote run. If / when Databricks implements this functionality natively, the code can be removed, but existing workflows won't require any changes.
If host is not provided, Databricks SDK will retrieve host and token for the DEFAULT profile.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#139 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, custom workflow
![image](https://github.com/Nike-Inc/brickflow/assets/43565398/50c9d175-9fc2-4099-81c3-102c1fa01a22)
![image](https://github.com/Nike-Inc/brickflow/assets/43565398/3cdf57ed-7697-4d3d-991a-834810b2f66b)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
