### PR TITLE
Patch fix ENV variable setter

### DIFF
--- a/brickflow/cli/configure.py
+++ b/brickflow/cli/configure.py
@@ -121,7 +121,7 @@ def bind_env_var(env_var: str) -> Callable:
         value: Any,
     ) -> None:
         # pylint: disable=unused-argument
-        if value is not None:
+        if value is not None and len(value) > 0:
             _ilog.info("Setting env var: %s to %s...", env_var, value)
             if isinstance(value, list):
                 os.environ[env_var] = ",".join(value)


### PR DESCRIPTION
Env variables are not getting set when using UNIX style.

BRICKFLOW_PROJECT_TAGS='name=pari' BRICKFLOW_PROJECT_PARAMS='name=pari' poetry run brickflow projects deploy --env local 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
