### PR TITLE
Allow optional end-date in get_execution_stats()

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ Thanks to the contributors who helped on this project apart from the authors
 * [Raju Gujjalapati](https://in.linkedin.com/in/raju-gujjalapati-470a88171)
 * [Madhusudan Koukutla](https://www.linkedin.com/in/madhusudan-reddy/)
 * [Surya Teja Jagatha](https://www.linkedin.com/in/surya-teja-jagatha/)
+* [Iris Meerman](https://www.linkedin.com/in/iris-meerman-92694675/)
 
 # Honorary Mentions
 Thanks to the team below for invaluable insights and support throughout the initial release of this project

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -220,7 +220,9 @@ class TaskDependencySensor(BaseSensorOperator):
         self._poke_count = 0
         self._start_time = time.time()
 
-    def get_execution_stats(self, execution_date: datetime, max_end_date: datetime = None):
+    def get_execution_stats(
+        self, execution_date: datetime, max_end_date: datetime = None
+    ):
         """Function to get the execution stats for task_id within a execution start time and
         (optionally) allowed job end time.
 
@@ -237,7 +239,11 @@ class TaskDependencySensor(BaseSensorOperator):
         execution_window_tz = (execution_date + execution_delta).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
-        max_end_date_filter = f"&end_date_lte={max_end_date.strftime('%Y-%m-%dT%H:%M:%SZ')}" if max_end_date else ""
+        max_end_date_filter = (
+            f"&end_date_lte={max_end_date.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            if max_end_date
+            else ""
+        )
         headers = {
             "Content-Type": "application/json",
             "cache-control": "no-cache",

--- a/brickflow_plugins/airflow/operators/external_tasks.py
+++ b/brickflow_plugins/airflow/operators/external_tasks.py
@@ -286,7 +286,7 @@ class TaskDependencySensor(BaseSensorOperator):
             if latest:
                 # Only picking the latest run id if latest flag is True
                 dag_run_id = list_of_dictionaries[0]["dag_run_id"]
-        log.info(f"Latest run for the dag is with execution date of  {dag_run_id}")
+        log.info(f"Latest run for the dag is with execution date of {dag_run_id}")
         log.info(
             f"Poking {external_dag_id} dag for {dag_run_id} run_id status as latest flag is set to {latest} "
         )

--- a/tests/airflow_plugins/test_task_dependency.py
+++ b/tests/airflow_plugins/test_task_dependency.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 import pytest
 from requests.exceptions import HTTPError
@@ -66,6 +66,33 @@ class TestTaskDependencySensor:
                 {"json": {"state": "success"}, "status_code": int(200)},
             ],
         )
+        # DAG Run Endpoint with max end date
+        rm.register_uri(
+            method="GET",
+            url=f"{BASE_URL}/api/v1/dags/test-dag/dagRuns?execution_date_gte=2024-01-01T00:00:00Z&end_date_lte=2024-01-01T01:20:00Z",
+            response_list=[
+                # Test 3: max end date specified
+                {
+                    "json": {
+                        "dag_runs": [
+                            {
+                                "conf": {},
+                                "dag_id": "test-dag",
+                                "dag_run_id": "manual__2024-01-01T01:00:00.000000+00:00",
+                                "end_date": "2024-01-01T01:10:00.000000+00:00",
+                                "execution_date": "2024-01-01T01:00:00.000000+00:00",
+                                "external_trigger": True,
+                                "logical_date": "2024-01-01T01:00:00.000000+00:00",
+                                "start_date": "2024-01-01T01:00:00.000000+00:00",
+                                "state": "success",
+                            },
+                        ],
+                        "total_entries": 1,
+                    },
+                    "status_code": int(200),
+                },
+            ],
+        )
         yield rm
 
     @pytest.fixture()
@@ -95,6 +122,8 @@ class TestTaskDependencySensor:
         with api:
             sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
 
+        print("iris")
+        print(caplog.text)
         assert (
             "No Runs found for test-dag dag after 2024-01-01T00:00:00Z, please check upstream dag"
             in caplog.text
@@ -128,3 +157,10 @@ class TestTaskDependencySensor:
         with pytest.raises(AirflowSensorTimeout):
             with rm:
                 sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
+
+    def test_end_date(self, api, caplog, sensor):
+        execution_date = datetime.strptime("2024-01-01T03:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        max_end_date = datetime.strptime("2024-01-01T01:20:00Z", "%Y-%m-%dT%H:%M:%SZ")
+        with api:
+            task_status = sensor.get_execution_stats(execution_date=execution_date, max_end_date=max_end_date)
+        assert task_status == "success"

--- a/tests/airflow_plugins/test_task_dependency.py
+++ b/tests/airflow_plugins/test_task_dependency.py
@@ -122,10 +122,8 @@ class TestTaskDependencySensor:
         with api:
             sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
 
-        print("iris")
-        print(caplog.text)
         assert (
-            "No Runs found for test-dag dag after 2024-01-01T00:00:00Z, please check upstream dag"
+            "No Runs found for test-dag dag in time window: 2024-01-01T00:00:00Z - now, please check upstream dag"
             in caplog.text
         )
         assert "task_status=running" in caplog.text

--- a/tests/airflow_plugins/test_task_dependency.py
+++ b/tests/airflow_plugins/test_task_dependency.py
@@ -69,7 +69,10 @@ class TestTaskDependencySensor:
         # DAG Run Endpoint with max end date
         rm.register_uri(
             method="GET",
-            url=f"{BASE_URL}/api/v1/dags/test-dag/dagRuns?execution_date_gte=2024-01-01T00:00:00Z&end_date_lte=2024-01-01T01:20:00Z",
+            url=(
+                f"{BASE_URL}/api/v1/dags/test-dag"
+                f"/dagRuns?execution_date_gte=2024-01-01T00:00:00Z&end_date_lte=2024-01-01T01:20:00Z"
+            ),
             response_list=[
                 # Test 3: max end date specified
                 {
@@ -156,7 +159,7 @@ class TestTaskDependencySensor:
             with rm:
                 sensor.execute(context={"execution_date": "2024-01-01T03:00:00Z"})
 
-    def test_end_date(self, api, caplog, sensor):
+    def test_end_date(self, api, sensor):
         execution_date = datetime.strptime("2024-01-01T03:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
         max_end_date = datetime.strptime("2024-01-01T01:20:00Z", "%Y-%m-%dT%H:%M:%SZ")
         with api:

--- a/tests/airflow_plugins/test_task_dependency.py
+++ b/tests/airflow_plugins/test_task_dependency.py
@@ -160,5 +160,7 @@ class TestTaskDependencySensor:
         execution_date = datetime.strptime("2024-01-01T03:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
         max_end_date = datetime.strptime("2024-01-01T01:20:00Z", "%Y-%m-%dT%H:%M:%SZ")
         with api:
-            task_status = sensor.get_execution_stats(execution_date=execution_date, max_end_date=max_end_date)
+            task_status = sensor.get_execution_stats(
+                execution_date=execution_date, max_end_date=max_end_date
+            )
         assert task_status == "success"


### PR DESCRIPTION

## Description
Add optional parameter of max end date for TaskDependcySensor get_execution_stats(). This is a minor change in order to not introduce a breaking change. However, if you agree I think it is more beautiful to have: 1) a function that returns the latest state of the run to be used for the 'poking' sensor, and have another 2) functionality that allows to query the API in a more flexible manner and allows to return more from the json response. 
This way we are more flexible, so we can use the start/end/state details to trigger different paths in the Brickflow DAGs (with IfElseConditionTask tasks) for instance. E.g. if the Airflow dependency was finished before time x, then branch in this direction, otherwise y direction. Or if latest run had status 'failed', then branch in direction z etc.

Right now it could be used like this:
```
tds = TaskDependencySensor(
            task_id=job["dag_id"],
            airflow_auth=AirflowProxyOktaClusterAuth(
                oauth2_conn_id=oauth2_conn_id,
                airflow_cluster_url=job["cluster_url"],
                airflow_version="2.0.2",
            ),
            external_dag_id=job["dag_id"],
            external_task_id=job["task_id"],
            allowed_states=["success"]
        )

execution_date = parse("2024-09-10T04:00:00.000000+00:00")
task_status = tds.get_execution_stats(execution_date=execution_date, max_end_date=max_end_date)
```

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/154

## Motivation and Context
See issue/above.

## How Has This Been Tested?
Tested locally and with unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. 
- [x] All new and existing tests passed.
