### PR TITLE
[fix] UcToSnowflakeOperator multiple grantees and avoid timestamp range error

### DIFF
--- a/brickflow_plugins/databricks/uc_to_snowflake_operator.py
+++ b/brickflow_plugins/databricks/uc_to_snowflake_operator.py
@@ -514,7 +514,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
         if self.authenticator is not None:
             sf_options["sfAuthenticator"] = self.authenticator
         self.log.info("snowflake package and options defined...!!!")
-        if len(source_df.take(1)) == 0:
+        if source_df.isEmpty():
             self.write_mode = "Append"
         if len(self.sf_cluster_keys) == 0:
             # Without order by clause compared to above

--- a/brickflow_plugins/databricks/uc_to_snowflake_operator.py
+++ b/brickflow_plugins/databricks/uc_to_snowflake_operator.py
@@ -317,6 +317,7 @@ class UcToSnowflakeOperator(SnowflakeOperator):
     sf_database (optional): database name in snowflake
     sf_schema   (required): snowflake schema in the database provided as part of scope
     sf_table    (required): name of the table in snowflake to which we want to append or overwrite
+    sf_grantee_roles (optional): downstream roles to which we want to grant access to the table, can be comma separated
     incremental_filter (optional): mandatory parameter for incremental load type to delete existing data in snowflake table
     dbx_data_filter (optional): parameter to filter databricks table if different from snowflake filter
     sf_cluster_keys (optional): list of keys to cluster the data in snowflake
@@ -376,17 +377,22 @@ class UcToSnowflakeOperator(SnowflakeOperator):
         return queries
 
     def get_sf_postgrants(self):
-        post_grantee_role = (
-            self.parameters["sf_grantee_roles"]
+        post_grantee_roles = (
+            self.parameters["sf_grantee_roles"].split(',')
             if "sf_grantee_roles" in self.parameters.keys()
-            else self.role
+            else [self.role]
         )
-        queries = """ GRANT SELECT ON TABLE {sfDatabase}.{sfSchema}.{sfTable} TO ROLE {sfGrantee_roles};""".format(
-            sfSchema=self.parameters["sf_schema"],
-            sfTable=self.parameters["sf_table"],
-            sfGrantee_roles=post_grantee_role,
-            sfDatabase=self.sf_database,
-        )
+        
+        queries = ""
+        for role in post_grantee_roles:
+            query = """GRANT SELECT ON TABLE {sfDatabase}.{sfSchema}.{sfTable} TO ROLE {sfGrantee_role}; """.format(
+                sfSchema=self.parameters["sf_schema"],
+                sfTable=self.parameters["sf_table"],
+                sfGrantee_role=role.strip(),
+                sfDatabase=self.sf_database,
+            )
+            queries += query
+        queries = queries.strip()
         return queries
 
     def validate_input_params(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added functionality to grant multiple roles after SF table is re-cloned.
- df.take(1) throws error on timestamps or dates with value 0001-01-01 - ValueError: year 0 is out of range. 
Pivot to .isEmpty() to avoid this.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
14.3-LTS
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
