### PR TITLE
[BUG] Missing common task parameters for Notebook Task

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -540,6 +540,16 @@ class DatabricksBundleCodegen(CodegenInterface):
                 f"Make sure {task_name} returns a NotebookTask object."
             ) from e
 
+        # Setting common task parameters if present
+        workflow: Optional[Workflow] = _kwargs.get("workflow")
+        common_task_parameters = workflow.common_task_parameters if workflow else None
+
+        if common_task_parameters:
+            notebook_task.base_parameters = notebook_task.base_parameters or {}
+            for k, v in common_task_parameters.items():
+                if k not in notebook_task.base_parameters:
+                    notebook_task.base_parameters[k] = v
+
         jt = JobsTasks(
             **task_settings.to_tf_dict(),
             notebook_task=notebook_task,

--- a/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_monorepo.yml
@@ -98,6 +98,9 @@ targets:
               min_retry_interval_millis: null
               notebook_task:
                 notebook_path: notebooks/notebook_a
+                base_parameters:
+                  all_tasks1: test
+                  all_tasks3: "123"
               retry_on_timeout: null
               task_key: notebook_task_a
               timeout_seconds: null

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo.yml
@@ -98,6 +98,9 @@ targets:
               min_retry_interval_millis: null
               notebook_task:
                 notebook_path: notebooks/notebook_a
+                base_parameters:
+                  all_tasks1: test
+                  all_tasks3: "123"
               retry_on_timeout: null
               task_key: notebook_task_a
               timeout_seconds: null

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
@@ -174,6 +174,9 @@ targets:
               min_retry_interval_millis: null
               notebook_task:
                 notebook_path: notebooks/notebook_a
+                base_parameters:
+                  all_tasks1: test
+                  all_tasks3: "123"
               retry_on_timeout: null
               task_key: notebook_task_a
               timeout_seconds: null

--- a/tests/codegen/expected_bundles/local_bundle.yml
+++ b/tests/codegen/expected_bundles/local_bundle.yml
@@ -125,6 +125,9 @@
             "min_retry_interval_millis": null
             "notebook_task":
               "notebook_path": "notebooks/notebook_a"
+              base_parameters:
+                all_tasks1: test
+                all_tasks3: "123"
             "retry_on_timeout": null
             "task_key": "notebook_task_a"
             "timeout_seconds": null

--- a/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
+++ b/tests/codegen/expected_bundles/local_bundle_prefix_suffix.yml
@@ -95,6 +95,9 @@ targets:
               min_retry_interval_millis: null
               notebook_task:
                 notebook_path: notebooks/notebook_a
+                base_parameters:
+                  all_tasks1: test
+                  all_tasks3: "123"
               retry_on_timeout: null
               task_key: notebook_task_a
               timeout_seconds: null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a task of `NotebookTask` type is used, it does not inherit the common parameters defined in the Workflow in `common_task_parameter`. This PR updates the codegen module in order to propagate these parameters from the workflow into the notebook task.

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/99

## Motivation and Context
See issue above.

## How Has This Been Tested?
Existing test cases have been updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
