### PR TITLE
Add fail_on_error parameter to SnowflakeOperator

### DIFF
--- a/brickflow_plugins/databricks/uc_to_snowflake_operator.py
+++ b/brickflow_plugins/databricks/uc_to_snowflake_operator.py
@@ -76,6 +76,7 @@ class SnowflakeOperator:
         *args,
         **kwargs,
     ):
+        self.conn = None
         self.cur = None
         self.query = None
         self.sql_file = None
@@ -199,12 +200,12 @@ class SnowflakeOperator:
                     self.secret_scope
                 )
             )
-            con = self.get_snowflake_connection()
+            self.conn = self.get_snowflake_connection()
         except snowflake.connector.errors.ProgrammingError as e:
             raise ValueError(
                 "Error {0} ({1}): {2} ({3})".format(e.errno, e.sqlstate, e.msg, e.sfqid)
             )
-        self.cur = con.cursor()
+        self.cur = self.conn.cursor()
 
     def snowflake_query_exec(self, cur, database, query_string):
         """
@@ -264,10 +265,11 @@ class SnowflakeOperator:
         # Run the query against SnowFlake
         try:
             self.snowflake_query_exec(self.cur, self.database, self.query)
-        except:
-            self.log.error("failed to execute")
+        except Exception as e:
+            self.log.error(f"Failed to execute")
+            raise e
         finally:
-            self.cur.close()
+            self.conn.close()
             self.log.info("Closed connection")
 
 

--- a/brickflow_plugins/databricks/uc_to_snowflake_operator.py
+++ b/brickflow_plugins/databricks/uc_to_snowflake_operator.py
@@ -65,6 +65,7 @@ class SnowflakeOperator:
     query_string : Optional parameter with queries separeted by semicolon(;)
     sql_file : Optional parameter with file path (relative to brickflow project root) to .sql file
     parameters: optional parameter dictionary with key value pairs to substitute in the query
+    fail_on_error: Optional parameter to fail the task on error, defaults to True
     """
 
     def __init__(
@@ -73,6 +74,7 @@ class SnowflakeOperator:
         query_string=None,
         sql_file=None,
         parameters={},
+        fail_on_error=True,
         *args,
         **kwargs,
     ):
@@ -84,6 +86,7 @@ class SnowflakeOperator:
         self.log = log
         self.query = query_string
         self.parameters = parameters
+        self.fail_on_error = fail_on_error
         self.sql_file = sql_file
         self.brickflow_root = get_bf_project_root()
 
@@ -266,8 +269,9 @@ class SnowflakeOperator:
         try:
             self.snowflake_query_exec(self.cur, self.database, self.query)
         except Exception as e:
-            self.log.error(f"Failed to execute")
-            raise e
+            if self.fail_on_error:
+                raise e
+            self.log.exception(f"Failed to execute")
         finally:
             self.conn.close()
             self.log.info("Closed connection")

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -96,7 +96,8 @@ def run_snowflake_queries(*args):
   sf_query_run = SnowflakeOperator(
     secret_scope = "your_databricks secrets scope name",
     query_string = "string of queries separated by semicolon(;)",
-    parameters={"key1":"value1", "key2":"value2"}
+    parameters={"key1":"value1", "key2":"value2"},
+    fail_on_error=True,
   )
   sf_query_run.execute()
 ```

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -697,22 +697,24 @@ def wait_on_workflow(*args):
 
 #### Snowflake Operator
 
-run snowflake queries from the databricks environment
+Run snowflake queries from the databricks environment
 
 As databricks secrets is a key value store, code expects the secret scope to contain the below exact keys
-&emsp;&emsp;&emsp;&emsp;username : user id created for connecting to snowflake for ex: sample_user  
-&emsp;&emsp;&emsp;&emsp;password : password information for about user for ex: P@$$word  
-&emsp;&emsp;&emsp;&emsp;account  : snowflake account information, not entire url for ex: sample_enterprise  
-&emsp;&emsp;&emsp;&emsp;warehouse: warehouse/cluster information that user has access for ex: sample_warehouse  
-&emsp;&emsp;&emsp;&emsp;database : default database that we want to connect for ex: sample_database  
-&emsp;&emsp;&emsp;&emsp;role     : role to which the user has write access for ex: sample_write_role
+
+- `username` : user id created for connecting to snowflake for ex: sample_user  
+- `password` : password information for about user for ex: P@$$word  
+- `account`  : snowflake account information, not entire url for ex: sample_enterprise  
+- `warehouse`: warehouse/cluster information that user has access for ex: sample_warehouse  
+- `database` : default database that we want to connect for ex: sample_database  
+- `role`     : role to which the user has write access for ex: sample_write_role
 
 SnowflakeOperator can accept the following as inputs
 
-&emsp;&emsp;&emsp;&emsp;secret_scope (required) : databricks secret scope identifier
-&emsp;&emsp;&emsp;&emsp;query_string (required) : queries separated by semicolon
-&emsp;&emsp;&emsp;&emsp;sql_file (optional) : path to the sql file
-&emsp;&emsp;&emsp;&emsp;parameters (optional) : dictionary with variables that can be used to substitute in queries
+- `secret_scope` : **(required)** databricks secret scope identifier
+- `query_string` : **(required)** queries separated by semicolon
+- `sql_file` : (optional) path to the sql file
+- `parameters` : (optional) dictionary with variables that can be used to substitute in queries
+- `fail_on_error` : (optional) bool to fail the task if there is a sql error, default is True
 
 Operator only takes one of either query_string or sql_file needs to be passed
 
@@ -726,7 +728,8 @@ def run_snowflake_queries(*args):
   sf_query_run = SnowflakeOperator(
     secret_scope = "your_databricks secrets scope name",
     query_string ="select * from database.$schema.$table where $filter_condition1; select * from sample_schema.test_table",
-    parameters = {"schema":"test_schema","table":"sample_table","filter_condition":"col='something'"}
+    parameters = {"schema":"test_schema","table":"sample_table","filter_condition":"col='something'"},
+    fail_on_error=True,
   )
   sf_query_run.execute()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current behavior of SnowflakeOperator does not fail when it hits a SQL error. 

Adds a `fail_on_error` parameter that defaults to `True`, so that the operator will raise exceptions and fail by default, but users can set it to `False` to keep the current behavior for whatever use case they have.

Also made some adjustments to close the connection instead of the cursor, and log the stacktrace if `fail_on_error=False`.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I noticed that the operator was returning success and not logging the error when a query failed to run on snowflake.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in 14.3-LTS
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
