### PR TITLE
[fix] issue 194: Uncaught exception IndexError when calling get_project_parameter

### DIFF
--- a/brickflow/context/context.py
+++ b/brickflow/context/context.py
@@ -399,7 +399,7 @@ class Context:
                 )
                 return debug
             return value
-        except KeyError:
+        except (KeyError, IndexError):
             # todo: log error
             _ilog.debug("Could not find the key in %s project params", project_params)
             return debug

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -204,7 +204,6 @@ class TestContext:
         dbutils.widgets.get.return_value = expected_value
 
         result = ctx.get_parameter(parameter_name)
-
         dbutils.widgets.get.assert_called_with(parameter_name)
         assert result == expected_value
 
@@ -219,3 +218,22 @@ class TestContext:
 
         result = ctx.get_project_parameter("k3", "v3")
         assert result == "v3"
+
+    @patch.dict(
+        os.environ,
+        {
+            BrickflowEnvVars.BRICKFLOW_PROJECT_PARAMS.value: "",
+        },
+    )
+    @patch("brickflow.context.ctx._dbutils")
+    def test_get_project_parameter_when_empty(self, dbutils: Mock):
+        parameter_name = BrickflowEnvVars.BRICKFLOW_PROJECT_PARAMS.value.lower()
+        expected_value = ""
+        dbutils.widgets.get.return_value = expected_value
+
+        result = ctx.get_parameter(parameter_name)
+        dbutils.widgets.get.assert_called_with(parameter_name)
+        assert result == expected_value
+
+        result = ctx.get_project_parameter("k1")
+        assert result is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Catching IndexError exception in context's `get_project_parameter` function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #194 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See #194

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a new unit test to cover scenario when no ENV variable `BRICKFLOW_PROJECT_PARAMS` is provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
