### PR TITLE
[FIX] - 184 Add missing data security modes

### DIFF
--- a/brickflow/engine/compute.py
+++ b/brickflow/engine/compute.py
@@ -104,6 +104,14 @@ class Runtimes:
 @dataclass(frozen=True)
 class DataSecurityMode:
     SINGLE_USER: str = "SINGLE_USER"
+    SHARED: str = "USER_ISOLATION"
+    NO_ISOLATION_SHARED: str = "NONE"
+
+    # The following modes are deprecated starting from dbr 15.0 and will be removed in future versions
+    LEGACY_TABLE_ACL: str = "LEGACY_TABLE_ACL"
+    LEGACY_PASSTHROUGH: str = "LEGACY_PASSTHROUGH"
+    LEGACY_SINGLE_USER: str = "LEGACY_SINGLE_USER"
+    LEGACY_SINGLE_USER_STANDARD: str = "LEGACY_SINGLE_USER_STANDARD"
 
 
 @dataclass(eq=True, frozen=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Missing data security modes have been added as configuration options for clusters

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/184

## Motivation and Context
Users could override the data security mode when configuring clusters, but picking values from an enum is a more convenient option

## How Has This Been Tested?
Deployments with all entries in the enum

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
