### PR TITLE
[FEATURE] Enhance support for debug mode

### DIFF
--- a/brickflow/cli/bundles.py
+++ b/brickflow/cli/bundles.py
@@ -71,11 +71,9 @@ def bundle_sync(
     if watch is True:
         additional_args.append("--watch")
     if interval_duration is not None:
-        additional_args.append("--interval-duration")
-        additional_args.append(str(interval_duration))
+        additional_args.append(f"--interval-duration {interval_duration}")
     if debug is True:
-        additional_args.append("--log-level")
-        additional_args.append("debug")
+        additional_args.append("--debug")
 
     exec_command(
         get_valid_bundle_cli(bundle_cli),
@@ -98,13 +96,21 @@ def get_force_lock_flag() -> str:
 
 @pre_bundle_hook
 def bundle_deploy(
-    bundle_cli: Optional[str] = None, force_acquire_lock: bool = False, **_: Any
+    bundle_cli: Optional[str] = None,
+    force_acquire_lock: bool = False,
+    auto_approve: bool = False,
+    debug: bool = False,
+    **_: Any,
 ) -> None:
     """CLI deploy the bundle."""
     deploy_args = ["deploy", ENV_FLAG, get_bundles_project_env()]
     if force_acquire_lock is True:
         # fix/issue-32
         deploy_args.append(get_force_lock_flag())
+    if auto_approve is True:
+        deploy_args.append("--auto-approve")
+    if debug is True:
+        deploy_args.append("--debug")
     exec_command(get_valid_bundle_cli(bundle_cli), "bundle", deploy_args)
 
 
@@ -113,6 +119,7 @@ def bundle_destroy(
     bundle_cli: Optional[str] = None,
     force_acquire_lock: bool = False,
     auto_approve: bool = False,
+    debug: bool = False,
     **_: Any,
 ) -> None:
     """CLI destroy the bundle."""
@@ -121,6 +128,8 @@ def bundle_destroy(
         destroy_args.append("--auto-approve")
     if force_acquire_lock is True:
         destroy_args.append(get_force_lock_flag())
+    if debug is True:
+        destroy_args.append("--debug")
 
     exec_command(get_valid_bundle_cli(bundle_cli), "bundle", destroy_args)
 

--- a/brickflow/cli/projects.py
+++ b/brickflow/cli/projects.py
@@ -490,6 +490,14 @@ def apply_bundles_deployment_options(
             default=False,
             help="Force acquire lock for databricks bundles destroy.",
         ),
+        "debug": click.option(
+            "--debug",
+            type=bool,
+            is_flag=True,
+            show_default=True,
+            default=False,
+            help="Enable debug logs.",
+        ),
         "workflow": click.option(
             "--workflow",
             "-w",
@@ -586,14 +594,6 @@ def project_synth(**_: Any) -> None:
     default=None,
     help="File system polling interval (for --watch).",
 )
-@click.option(
-    "--debug",
-    type=bool,
-    is_flag=True,
-    show_default=True,
-    default=False,
-    help="Enable debug logs",
-)
 @apply_bundles_deployment_options
 def sync_project(project: str, **kwargs: Any) -> None:
     """Sync project file tree into databricks workspace from local.
@@ -609,10 +609,7 @@ def sync_project(project: str, **kwargs: Any) -> None:
 
 @projects.command(name="synth")
 @apply_bundles_deployment_options(
-    exclude_options=[
-        "auto-approve",
-        "force-acquire-lock",
-    ]
+    exclude_options=["auto-approve", "force-acquire-lock", "debug"]
 )
 def synth_bundles_for_project(project: str, **kwargs: Any) -> None:
     """Synth the bundle.yml for project"""

--- a/tests/cli/test_bundles.py
+++ b/tests/cli/test_bundles.py
@@ -14,19 +14,19 @@ class TestBundles:
         mock_exec_command.side_effect = lambda *args, **kwargs: None
         mock_exec_command.return_value = None
         # workflows_dir needed to make the function work due to bundle sync
-        bundle_deploy(force_acquire_lock=True, workflows_dir="somedir")
+        bundle_deploy(force_acquire_lock=True, workflows_dir="somedir", debug=True)
         bundle_cli = os.environ[BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_EXEC.value]
         mock_exec_command.assert_called_with(
             bundle_cli,
             "bundle",
-            ["deploy", "-t", "local", "--force-lock"],
+            ["deploy", "-t", "local", "--force-lock", "--debug"],
         )
-        bundle_destroy(force_acquire_lock=True, workflows_dir="somedir")
+        bundle_destroy(force_acquire_lock=True, workflows_dir="somedir", debug=True)
         bundle_cli = os.environ[BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_EXEC.value]
         mock_exec_command.assert_called_with(
             bundle_cli,
             "bundle",
-            ["destroy", "-t", "local", "--force-lock"],
+            ["destroy", "-t", "local", "--force-lock", "--debug"],
         )
 
     @patch("brickflow.cli.bundles.exec_command")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`bf projects deploy` and `bf projects destroy` can now be run in debug mode.
> [!NOTE]
> As a subsidiary part of this feature, `bf projects deploy` now also supports the `--auto-approve` flag (which `bf projects destroy` already does), to keep up with the related Databricks CLI version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/brickflow/issues/200

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the debug mode is only supported for `bf projects sync`. And given that the `debug` option is a global Databricks CLI flag, we should leverage it for `bf projects deploy` and `bf projects destroy` too (handy for troubleshooting).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit & integration tests

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.