### PR TITLE
[bugfix] WorkflowDependencySensor doesn't fail the workflow run if invalid "dependency_job_id" is given

### DIFF
--- a/brickflow_plugins/databricks/workflow_dependency_sensor.py
+++ b/brickflow_plugins/databricks/workflow_dependency_sensor.py
@@ -153,6 +153,16 @@ class WorkflowDependencySensor:
         )
 
     def execute(self):
+        if self.dependency_job_id:
+            # DBX API always returns PermissionDenied, even if the job_id doesn't exist
+            try:
+                self._workspace_obj.jobs.get(job_id=self.dependency_job_id)
+            except AttributeError as ex:
+                if any("PermissionDenied" in arg for arg in ex.args):
+                    raise WorkflowDependencySensorException(
+                        f"Job '{self.dependency_job_id}' does not exist or you don't have permission to view it."
+                    )
+
         if not self.dependency_job_id:
             self.dependency_job_id = self._get_job_id
 

--- a/tests/databricks_plugins/test_workflow_dependency_sensor.py
+++ b/tests/databricks_plugins/test_workflow_dependency_sensor.py
@@ -31,8 +31,8 @@ class TestWorkflowDependencySensor:
             with pytest.raises(WorkflowDependencySensorException) as ex:
                 sensor.execute()
 
-            assert any(
-                "Job with id '1' does not exist or you don't have permission to view it."
-                in arg
-                for arg in ex.value.args
-            )
+                assert any(
+                    "Job with id '1' does not exist or you don't have permission to view it."
+                    in arg
+                    for arg in ex.value.args
+                )

--- a/tests/databricks_plugins/test_workflow_dependency_sensor.py
+++ b/tests/databricks_plugins/test_workflow_dependency_sensor.py
@@ -1,0 +1,38 @@
+from datetime import timedelta
+
+import pytest
+from requests_mock.mocker import Mocker as RequestsMocker
+
+from brickflow_plugins.databricks.workflow_dependency_sensor import (
+    WorkflowDependencySensor,
+    WorkflowDependencySensorException,
+)
+
+
+class TestWorkflowDependencySensor:
+    workspace_url = "https://42.cloud.databricks.com"
+    endpoint_url = f"{workspace_url}/api/2.1/jobs/get"
+    response = {}
+
+    def test_sensor_failure_403(self):
+        api = RequestsMocker()
+        api.get(self.endpoint_url, json=self.response, status_code=int(403))
+
+        with api:
+            sensor = WorkflowDependencySensor(
+                databricks_host=self.workspace_url,
+                databricks_token="token",
+                dependency_job_id="1",
+                delta=timedelta(seconds=1),
+                timeout_seconds=1,
+                poke_interval_seconds=1,
+            )
+
+            with pytest.raises(WorkflowDependencySensorException) as ex:
+                sensor.execute()
+
+            assert any(
+                "Job with id '1' does not exist or you don't have permission to view it."
+                in arg
+                for arg in ex.value.args
+            )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When job_id us provided to the operator, the existence of the job with the corresponding id will be checked via the Databricks workspace client. Note, that client always returns 403 (access denied) even if the job does not exist.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#76 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If user leverages job id (instead of name, despite the deprecation warning), the sensor will run indefinitly or until timeout is reached. However it should fail because the job does not exist or is not accessible by the user or a service principal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
