### PR TITLE
[BUG] - 46 Deployment failing instead of skipping when no files are synthesized

### DIFF
--- a/brickflow/cli/bundles.py
+++ b/brickflow/cli/bundles.py
@@ -82,6 +82,11 @@ def bundle_sync(
     )
 
 
+def should_deploy() -> bool:
+    """This has been added mostly for testing purposes as directly mocking os.path.exists has broader impacts"""
+    return os.path.exists("bundle.yml")
+
+
 def get_force_lock_flag() -> str:
     version_parts = get_bundle_cli_version().split(".")
     # TODO: remove this logic on the major version
@@ -103,6 +108,11 @@ def bundle_deploy(
     **_: Any,
 ) -> None:
     """CLI deploy the bundle."""
+    # If the bundle.yml has not been synthesized, there's nothing to deploy!
+    if not should_deploy():
+        _ilog.warning("No bundle.yml found, skipping deployment.")
+        return
+
     deploy_args = ["deploy", ENV_FLAG, get_bundles_project_env()]
     if force_acquire_lock is True:
         # fix/issue-32

--- a/tests/cli/test_bundles.py
+++ b/tests/cli/test_bundles.py
@@ -1,16 +1,19 @@
+import logging
 import os
 from unittest.mock import patch, Mock
+from pytest import LogCaptureFixture
 
-from brickflow import BrickflowEnvVars
+from brickflow import BrickflowEnvVars, _ilog
 from brickflow.cli.bundles import bundle_deploy, bundle_destroy
 
 
 class TestBundles:
+    @patch("brickflow.cli.bundles.should_deploy", return_value=True)
     @patch("brickflow.cli.bundles.exec_command")
     @patch.dict(
         os.environ, {BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_VERSION.value: "0.203.0"}
     )
-    def test_bundle_deploy_new_cli(self, mock_exec_command: Mock):
+    def test_bundle_deploy_new_cli(self, mock_exec_command: Mock, _: Mock):
         mock_exec_command.side_effect = lambda *args, **kwargs: None
         mock_exec_command.return_value = None
         # workflows_dir needed to make the function work due to bundle sync
@@ -29,6 +32,7 @@ class TestBundles:
             ["destroy", "-t", "local", "--force-lock", "--debug"],
         )
 
+    @patch("brickflow.cli.bundles.should_deploy", return_value=True)
     @patch("brickflow.cli.bundles.exec_command")
     @patch.dict(
         os.environ,
@@ -37,7 +41,7 @@ class TestBundles:
             BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_EXEC.value: "databricks",
         },
     )
-    def test_bundle_deploy_old_cli(self, mock_exec_command: Mock):
+    def test_bundle_deploy_old_cli(self, mock_exec_command: Mock, _: Mock):
         mock_exec_command.side_effect = lambda *args, **kwargs: None
         mock_exec_command.return_value = None
         # workflows_dir needed to make the function work due to bundle sync
@@ -55,3 +59,25 @@ class TestBundles:
             "bundle",
             ["destroy", "-t", "local", "--force"],
         )
+
+    @patch("brickflow.cli.bundles.exec_command")
+    @patch.dict(
+        os.environ, {BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_VERSION.value: "0.203.0"}
+    )
+    def test_deploy_no_workflows(
+        self, mock_exec_command: Mock, caplog: LogCaptureFixture
+    ):
+        mock_exec_command.side_effect = lambda *args, **kwargs: None
+        mock_exec_command.return_value = None
+
+        # Adjusting the log level and propagating it to the root logger to make sure it's captured by caplog
+        _ilog.propagate = True
+        _ilog.level = logging.WARN
+
+        with caplog.at_level(logging.WARN):
+            # running this should not fail but log a warning stating that no bundle has been found
+            bundle_deploy(force_acquire_lock=True, workflows_dir="somedir")
+
+        assert "No bundle.yml found, skipping deployment." in [
+            rec.message for rec in caplog.records
+        ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a brickflow project is created but no workflows are associated to it, deployment will fail while it should be just skipped.

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/46

## Motivation and Context
See description.

## How Has This Been Tested?
- unit test
- manual deployment of such brickflow projects, together with standard project with workflows configured

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
