### PR TITLE
WIP: support intra-project workflow references for RunAsJob

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -669,19 +669,36 @@ class DatabricksBundleCodegen(CodegenInterface):
         depends_on: List[JobsTasksDependsOn],
         **_kwargs: Any,
     ) -> JobsTasks:
-        run_job_task: JobsTasksRunJobTask = task.task_func()
+        run_job_task: JobsTasksRunJobTask | Workflow = task.task_func()
 
         try:
-            assert isinstance(run_job_task, JobsTasksRunJobTask)
+            assert isinstance(run_job_task, JobsTasksRunJobTask) or isinstance(
+                run_job_task, Workflow
+            )
         except AssertionError as e:
             raise ValueError(
                 f"Error while building run job task {task_name}. "
-                f"Make sure {task_name} returns a RunJobTask object."
+                f"Make sure {task_name} returns a RunJobTask or Workflow object."
             ) from e
+
+        job_id = None
+
+        if isinstance(run_job_task, JobsTasksRunJobTask):
+            job_id = run_job_task.job_id
+        elif isinstance(run_job_task, Workflow):
+            # If the task is a workflow, we need to set the job_id and job_name
+            # based on the workflow name. The job_id will be used in the JobsTasks.
+            # Uncomment the following lines if you want to handle workflow references
+            # in a specific way (e.g., using a custom naming convention).
+            if self.project.workflow_exists(run_job_task) is False:
+                raise ValueError(
+                    f"Workflow {run_job_task.name} does not exist in the current project."
+                )
+            job_id = f"${{resources.jobs.{run_job_task.name}.id}}"
 
         return JobsTasks(
             **task_settings.to_tf_dict(),  # type: ignore
-            run_job_task=JobsTasksRunJobTask(job_id=run_job_task.job_id),
+            run_job_task=JobsTasksRunJobTask(job_id=job_id),
             depends_on=depends_on,
             task_key=task_name,
         )

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -415,7 +415,7 @@ class Workflow:
         # enforce notebook type execution and replacing the original callable function with the RunJobInRemoteWorkspace
         if task_type == TaskType.RUN_JOB_TASK:
             func = f()
-            if func.host:
+            if hasattr(func, "host") and func.host:
                 from brickflow_plugins.databricks.run_job import RunJobInRemoteWorkspace
 
                 task_type = TaskType.BRICKFLOW_TASK


### PR DESCRIPTION
Ability to register run as task referencing workflows within the brickflow project. Since everything in the project is shipped as a bundle this is possible. 

## Description
Support for the following:
```
@wf.run_job_task(depends_on=branch)
def foobar():
    from dataaisummit.workflows.demo_summit import wf as demo_summit_wf
    return demo_summit_wf
```

## Motivation and Context
Make it very very easy to create dependent workflows in the same deployment. This works using bundle references. 

This is only possible if all the reference workflows are in the same bundle and a brickflow project maps to a bundle thus making this possible. Very minor code changes were needed to support this and existing functionality should continue to work as expected.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/af45696c-00f4-4246-bd74-001fe93ebb12" />


## How Has This Been Tested?
Manual testing at the moment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
