### PR TITLE
[BUG] 222 - For each task executes nested brickflow task during deployment

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -520,6 +520,7 @@ The `for_each_task` decorator can be configured by providing in the `for_each_ta
 
 - **inputs: Optional[str]**: the list of input values to iterate over. This can be a python iterable, or a string representing a JSON formatted array of values.
 - **for_each_task_concurrency: Optional[int]**: the number of concurrent executions of the task. Default is 1.
+- **task_type: Optional[TaskType]**: the type of task to iterate over. While this is not required, for nested brickflow type tasks it's recommended to set it accordingly otherwise the task could be unintentionally run during deployment. This attribute will likely be mandatory in a future minor release. 
 
 A reference to the current input value we are iterating on can be accessed using `{{input}}` databricks workflow parameter.
 
@@ -549,7 +550,7 @@ def example_notebook():
 @wf.for_each_task(
     depends_on=example_task,
     for_each_task_conf=JobsTasksForEachTaskConfigs(
-        inputs='["1", "2", "3"]', concurrency=3
+        inputs='["1", "2", "3"]', concurrency=3, task_type=TaskType.BRICKFLOW_TASK
     ),
 )
 def example_brickflow_task(*, test_param="{{input}}"):

--- a/tests/codegen/sample_workflows.py
+++ b/tests/codegen/sample_workflows.py
@@ -424,8 +424,7 @@ def first_notebook():
 @wf3.for_each_task(
     depends_on=first_notebook,
     for_each_task_conf=JobsTasksForEachTaskConfigs(
-        concurrency=3,
-        inputs="[1, 2, 3]",
+        concurrency=3, inputs="[1, 2, 3]", task_type=TaskType.NOTEBOOK_TASK
     ),
 )
 def for_each_notebook():
@@ -439,12 +438,14 @@ def for_each_notebook():
 @wf3.for_each_task(
     depends_on=first_notebook,
     for_each_task_conf=JobsTasksForEachTaskConfigs(
-        inputs=["1", "2", "3"],
-        concurrency=1,
+        inputs=["1", "2", "3"], concurrency=1, task_type=TaskType.BRICKFLOW_TASK
     ),
 )
 def for_each_bf_task(*, looped_parameter="{{input}}"):
     print(f"This is a nested bf task running with input: {looped_parameter}")
+    raise ValueError(
+        "This should not be raised during codegen if we provide the task_type!"
+    )
 
 
 @wf3.for_each_task(

--- a/tests/engine/test_task.py
+++ b/tests/engine/test_task.py
@@ -41,6 +41,7 @@ from brickflow.engine.task import (
     get_brickflow_libraries,
     get_brickflow_tasks_hook,
     get_plugin_manager,
+    TaskType,
 )
 from brickflow.engine.utils import get_job_id
 from tests.engine.sample_workflow import (
@@ -674,3 +675,35 @@ class TestTask:
         )
 
         assert for_each_task.inputs == '["input1", "input2"]'
+
+    def test_for_each_task_validation_task_type(self):
+        # Valid task type
+        for_each_task = ForEachTask(
+            configs=JobsTasksForEachTaskConfigs(
+                inputs=["input1", "input2"],
+                concurrency=2,
+                task_type=TaskType.NOTEBOOK_TASK,
+            ),
+            task=JobsTasks(task_key="task_key"),
+        )
+        assert for_each_task.configs.task_type == TaskType.NOTEBOOK_TASK
+
+        # Not providing a task type should set task type to None
+        for_each_task = ForEachTask(
+            configs=JobsTasksForEachTaskConfigs(
+                inputs=["input1", "input2"], concurrency=2
+            ),
+            task=JobsTasks(task_key="task_key"),
+        )
+        assert for_each_task.configs.task_type is None
+
+        # Setting a task type with a value other than the valid ones should raise a ValueError
+        with pytest.raises(ValueError):
+            ForEachTask(
+                configs=JobsTasksForEachTaskConfigs(
+                    inputs=["input1", "input2"],
+                    concurrency=2,
+                    task_type=TaskType.IF_ELSE_CONDITION_TASK,
+                ),
+                task=JobsTasks(task_key="task_key"),
+            )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR avoids executing brickflow type for each tasks during bundle generation.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When configuring a for each task, it is not required to provide a nested task type as the builder function simply executes the callable to get in return the task object. This is then used to detect the nested task type and resolve the nested task builder function. While this works out fine with other task types, as brickflow tasks do not return an associated task object, this behaviour was causing the task to be executed during deployment.

To solve that, this PR adds an optional `task_type` attribute in the for each task model to make the builder function aware of the type preventing it to run it if type is indeed brickflow.

This PR targets a patch release: users currently experiencing this issue can start providing the task type as brickflow task to avoid execution. To streamline and simplify the builder function, in the next minor release we could make the `task_type` attribute mandatory.

## How Has This Been Tested?
Additional unit tests for task type validation were added, existing for each task bundle generation tests were modified to account for edge cases.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
