### PR TITLE
Add support for fail-on-active-runs flag

### DIFF
--- a/brickflow/cli/bundles.py
+++ b/brickflow/cli/bundles.py
@@ -102,6 +102,7 @@ def get_force_lock_flag() -> str:
 @pre_bundle_hook
 def bundle_deploy(
     bundle_cli: Optional[str] = None,
+    fail_on_active_runs: bool = False,
     force_acquire_lock: bool = False,
     auto_approve: bool = False,
     debug: bool = False,
@@ -114,6 +115,13 @@ def bundle_deploy(
         return
 
     deploy_args = ["deploy", ENV_FLAG, get_bundles_project_env()]
+    if fail_on_active_runs is True:
+        # TODO: Remove the following message once the CLI is upgraded to >= 0.249.0.
+        _ilog.info(
+            "Note that, even with `fail-on-active-runs` being enabled, the deployment might fail, "
+            "in some edge cases (particularly if the bundle includes some wheel artifacts)."
+        )
+        deploy_args.append("--fail-on-active-runs")
     if force_acquire_lock is True:
         # fix/issue-32
         deploy_args.append(get_force_lock_flag())

--- a/brickflow/cli/projects.py
+++ b/brickflow/cli/projects.py
@@ -482,6 +482,14 @@ def apply_bundles_deployment_options(
             default=False,
             help="Skip automatically adding brickflow libraries.",
         ),
+        "fail-on-active-runs": click.option(
+            "--fail-on-active-runs",
+            type=bool,
+            is_flag=True,
+            show_default=True,
+            default=False,
+            help="Fail if there are running jobs or pipelines in the deployment.",
+        ),
         "force-acquire-lock": click.option(
             "--force-acquire-lock",
             type=bool,

--- a/tests/cli/test_bundles.py
+++ b/tests/cli/test_bundles.py
@@ -17,12 +17,24 @@ class TestBundles:
         mock_exec_command.side_effect = lambda *args, **kwargs: None
         mock_exec_command.return_value = None
         # workflows_dir needed to make the function work due to bundle sync
-        bundle_deploy(force_acquire_lock=True, workflows_dir="somedir", debug=True)
+        bundle_deploy(
+            force_acquire_lock=True,
+            workflows_dir="somedir",
+            debug=True,
+            fail_on_active_runs=True,
+        )
         bundle_cli = os.environ[BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_EXEC.value]
         mock_exec_command.assert_called_with(
             bundle_cli,
             "bundle",
-            ["deploy", "-t", "local", "--force-lock", "--debug"],
+            [
+                "deploy",
+                "-t",
+                "local",
+                "--fail-on-active-runs",
+                "--force-lock",
+                "--debug",
+            ],
         )
         bundle_destroy(force_acquire_lock=True, workflows_dir="somedir", debug=True)
         bundle_cli = os.environ[BrickflowEnvVars.BRICKFLOW_BUNDLE_CLI_EXEC.value]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`bf projects deploy` now accepts a `fail-on-active-runs` flag.
> [!IMPORTANT]
> Even when the aforementioned flag is on, the deployment might fail in some _edgy_ cases, particularly when the bundle includes wheel artifacts. This is not specific to the flag itself, but rather to closely-related internals of the CLI (fixed as of 0.249.0). 

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/232

## Motivation and Context
Deploying a bundle when there are bound resources (e.g. jobs) running at the same time can be disruptive. Hence adding support for the `fail-on-active-runs` flag, which is already supported by the Databricks CLI.

## How Has This Been Tested?
Unit & integration tests

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
