### PR TITLE
Fixing a bug, including aarch64

### DIFF
--- a/brickflow/cli/bundles.py
+++ b/brickflow/cli/bundles.py
@@ -153,15 +153,18 @@ def bundle_destroy(
 
 
 def get_arch() -> str:
-    architecture = platform.machine()
-
-    if architecture in ("i386", "i686"):
-        architecture = "386"
-    elif architecture == "x86_64":
-        architecture = "amd64"
-    elif architecture.startswith("arm"):
-        architecture = "arm64"
-    return architecture
+    system = platform.machine().lower()
+    arch_map = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "i386": "386",
+        "i686": "386",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }
+    if system not in arch_map:
+        raise RuntimeError(f"Unsupported architecture: {system}")
+    return arch_map[system]
 
 
 def bundle_download_path(version: str) -> str:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -56,6 +56,7 @@ wf = Workflow(  # (1)!
         "value": 7200
     },
     parameters=[JobsParameters(default="INFO", name="jp_logging_level")],  # (18)!
+    queue = True,  # (20)!
 )
 
 
@@ -83,6 +84,7 @@ def task_function(*, test="var"):
 17. Define timeout_seconds check condition that triggers workflow failure if duration exceeds threshold
 18. Define the parameters on workflow level [databricks docs](https://docs.databricks.com/en/jobs/settings.html#job-parameters)
 19. Define the notification settings for the workflow
+20. To prevent runs of a job from being skipped because of concurrency limits, you can enable queueing for the job
 
 ### Clusters
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed architecture detection for ARM64 Linux machines by improving the `get_arch()` function in `bundles.py`. The function now correctly handles multiple architecture identifiers and returns standardized architecture strings for the Databricks CLI download URL.

- Updated architecture mapping to handle both `arm64` and `aarch64` identifiers
- Improved test coverage using parametrized tests to verify all architecture mappings
- Added case insensitivity handling for architecture detection
- Added explicit error handling for unsupported architectures

Also update docs to add explanation for `queue` in workflows

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#94 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix ensures correct CLI bundle downloads on ARM64 Linux machines, particularly when `platform.machine()` returns "aarch64" instead of "arm64".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
