### PR TITLE
[BUG] 244 - Cannot deploy workflow without health rule

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -1075,7 +1075,7 @@ class DatabricksBundleCodegen(CodegenInterface):
                 name=workflow_name,
                 tasks=tasks,
                 tags=workflow.tags,
-                health=JobsHealth(rules=workflow.health),
+                health=JobsHealth(rules=workflow.health) if workflow.health else None,
                 job_clusters=[JobsJobClusters(**c) for c in workflow_clusters],
                 schedule=self.workflow_obj_to_schedule(workflow),
                 max_concurrent_runs=workflow.max_concurrent_runs,

--- a/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
+++ b/tests/codegen/expected_bundles/dev_bundle_polyrepo_with_auto_libs.yml
@@ -6,7 +6,6 @@ targets:
       jobs:
         some_wf:
           email_notifications: null
-          health: {}
           trigger: null
           git_source:
             git_commit: a

--- a/tests/codegen/expected_bundles/local_bundle_foreach_task.yml
+++ b/tests/codegen/expected_bundles/local_bundle_foreach_task.yml
@@ -5,7 +5,6 @@
     "resources":
       "jobs":
         "wf-foreach-task-test":
-          "health": {}
           "job_clusters":
             - "job_cluster_key": "sample_job_cluster"
               "new_cluster":

--- a/tests/codegen/expected_bundles/local_serverless_bundle.yml
+++ b/tests/codegen/expected_bundles/local_serverless_bundle.yml
@@ -13,7 +13,6 @@
               "client": "1"
               "dependencies":
               - "pytz==2024.2"
-          "health": {}
           "job_clusters": []
           "max_concurrent_runs": 1.0
           "name": "test_user_brickflow-serverless-demo"


### PR DESCRIPTION
## Description
Workflow could not be configured without health rules as it was failing validation. Now if health rules are not set, the corresponding property will be set to None instead.

## Related Issue
https://github.com/Nike-Inc/brickflow/issues/244

## How Has This Been Tested?
Unit tests and manual deployments with both health rules provided and not provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
