### PR TITLE
feat: file-based runtime dispatch for injected tasks

### DIFF
--- a/brickflow/codegen/databricks_bundle.py
+++ b/brickflow/codegen/databricks_bundle.py
@@ -50,6 +50,7 @@ from brickflow.bundles.model import (
     PipelinesLibraries,
     PipelinesLibrariesNotebook,
     Resources,
+    Sync,
     Targets,
     Workspace,
     JobsQueue,
@@ -1151,11 +1152,18 @@ class DatabricksBundleCodegen(CodegenInterface):
             resources=resources,
         )
 
+        # If injected task files were written, force DAB to sync them even
+        # when the directory is in .gitignore.
+        sync = None
+        if Path("_brickflow_injected").is_dir():
+            sync = Sync(include=["_brickflow_injected/**"])
+
         return DatabricksAssetBundles(
             targets={
                 get_bundles_project_env(): env_content,
             },
             bundle=Bundle(name=self.project.name),
+            sync=sync,
             workspace=Workspace(),  # empty required not optional
         )
 

--- a/brickflow/context/context.py
+++ b/brickflow/context/context.py
@@ -54,6 +54,8 @@ class BrickflowInternalVariables(Enum):
     workflow_prefix = "brickflow_internal_workflow_prefix"
     workflow_suffix = "brickflow_internal_workflow_suffix"
     env = BrickflowEnvVars.BRICKFLOW_ENV.value.lower()
+    injection_config = "brickflow_internal_injection_config"
+    injection_file_path = "brickflow_internal_injection_file_path"
 
 
 def bind_variable(builtin: BrickflowBuiltInTaskVariables) -> Callable:

--- a/brickflow/engine/project.py
+++ b/brickflow/engine/project.py
@@ -25,7 +25,9 @@ from brickflow.codegen.databricks_bundle import DatabricksBundleCodegen
 from brickflow.context import ctx, BrickflowInternalVariables
 from brickflow.engine import get_current_commit, ROOT_NODE
 from brickflow.engine.task import (
+    Task,
     TaskLibrary,
+    TaskNotFoundError,
     filter_bf_related_libraries,
     get_brickflow_libraries,
     TaskType,
@@ -228,6 +230,18 @@ class _Project:
                 executor = GenericTaskExecutor(task_def)
                 task_func = executor.create_task_function()
 
+                # Pre-render template and serialize so the runtime can
+                # reconstruct this task without needing the YAML / env vars.
+                try:
+                    injection_config_json = executor.serialize_for_runtime()
+                except Exception as ser_err:
+                    _ilog.warning(
+                        "Could not serialize injection config for '%s': %s",
+                        task_def.task_name,
+                        ser_err,
+                    )
+                    injection_config_json = None
+
                 # Build libraries list
                 task_libraries = self._build_task_libraries(
                     task_def.libraries,
@@ -255,6 +269,7 @@ class _Project:
                     task_type=TaskType[task_def.task_type],
                     libraries=task_libraries,
                     cluster=cluster,
+                    injection_config_json=injection_config_json,
                 )
 
                 # For "all_tasks" strategy, make all root tasks depend on injected task
@@ -574,5 +589,69 @@ class Project:
                 return
 
             workflow = self._project.get_workflow(wf_id)
-            task = workflow.get_task(t_id)
+
+            try:
+                task = workflow.get_task(t_id)
+            except Exception:
+                # Task not found — this happens for injected tasks at runtime
+                # because the injection YAML / env vars are not on the cluster.
+                # Fall back to reconstructing the task from the baked config
+                # that was embedded in base_parameters at deploy time.
+                task = self._reconstruct_injected_task(workflow, t_id)
+
             task.execute()
+
+    @staticmethod
+    def _reconstruct_injected_task(workflow: Workflow, task_id: str) -> Task:
+        """
+        Reconstruct an injected task at runtime from its baked config.
+
+        At deploy time the rendered template code is written to a ``.py``
+        file that DAB syncs to the workspace.  A lightweight JSON pointer
+        (task name, type, relative file ref) is stored in
+        ``brickflow_internal_injection_config``, and the fully-resolved
+        workspace path is in ``brickflow_internal_injection_file_path``
+        (DAB substitutes ``${workspace.file_path}`` at deploy time).
+
+        When the entrypoint re-runs on the cluster and the task is not in
+        the workflow registry, this method reads those parameters and
+        re-creates the ``Task`` object so execution can proceed.
+        """
+        from brickflow.engine.task_executor import GenericTaskExecutor
+
+        injection_config = ctx.get_parameter(
+            BrickflowInternalVariables.injection_config.value, None
+        )
+
+        if not injection_config:
+            from brickflow.engine.utils import wraps_keyerror as _  # noqa: F401
+
+            raise TaskNotFoundError(
+                f"Unable to find task: '{task_id}'. "
+                "No baked injection config was found in base_parameters either. "
+                "Ensure the task was deployed with a Brickflow version that "
+                "supports runtime injection config (>= 1.8.0)."
+            )
+
+        workspace_file_path = ctx.get_parameter(
+            BrickflowInternalVariables.injection_file_path.value, None
+        )
+
+        _ilog.info(
+            "Task '%s' not in workflow registry — reconstructing from "
+            "baked injection config (file_path=%s)",
+            task_id,
+            workspace_file_path,
+        )
+
+        task_func = GenericTaskExecutor.create_task_function_from_config(
+            injection_config, workspace_file_path=workspace_file_path
+        )
+
+        workflow._add_task(
+            f=task_func,
+            task_id=task_id,
+            task_type=TaskType.BRICKFLOW_TASK,
+        )
+
+        return workflow.get_task(task_id)

--- a/brickflow/engine/task.py
+++ b/brickflow/engine/task.py
@@ -933,6 +933,7 @@ class Task:
     health: Optional[List[JobsTasksHealthRules]] = None
     if_else_outcome: Optional[Dict[Union[str, str], str]] = None
     for_each_task_conf: Optional[JobsTasksForEachTaskConfigs] = None
+    injection_config_json: Optional[str] = None
 
     def __post_init__(self) -> None:
         self.is_valid_task_signature()
@@ -983,7 +984,7 @@ class Task:
 
     @property
     def brickflow_default_params(self) -> Dict[str, str]:
-        return {
+        params = {
             BrickflowInternalVariables.workflow_id.value: self.workflow.name,
             # 2 braces to escape 1
             BrickflowInternalVariables.task_id.value: f"{{{{{BrickflowBuiltInTaskVariables.task_key.name}}}}}",
@@ -994,6 +995,22 @@ class Task:
             or "",
             BrickflowInternalVariables.env.value: ctx.env,
         }
+        if self.injection_config_json:
+            params[BrickflowInternalVariables.injection_config.value] = (
+                self.injection_config_json
+            )
+            try:
+                cfg = json.loads(self.injection_config_json)
+                file_ref = cfg.get("file_ref")
+                if file_ref:
+                    # ${workspace.file_path} already includes the /Workspace/
+                    # prefix after DAB resolution.
+                    params[BrickflowInternalVariables.injection_file_path.value] = (
+                        f"${{workspace.file_path}}/{file_ref}"
+                    )
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return params
 
     @staticmethod
     def handle_notebook_path(entrypoint: str) -> str:
@@ -1276,7 +1293,11 @@ def get_brickflow_libraries(enable_plugins: bool = False) -> List[TaskLibrary]:
     is_bf_version_semver = is_semver(bf_version)
     is_all_parts_numeric = all(v.isnumeric() for v in bf_version.split("."))
 
-    if is_bf_version_semver is True and is_all_parts_numeric is True:
+    # TEMPORARY: point at fork branch for e2e testing of injection fix
+    _override = os.environ.get("BRICKFLOW_RUNTIME_GIT_REF")
+    if _override:
+        bf_lib = PypiTaskLibrary(f"brickflows @ git+{_override}")
+    elif is_bf_version_semver is True and is_all_parts_numeric is True:
         bf_lib = PypiTaskLibrary(f"brickflows=={bf_version}")
     else:
         bf_lib = PypiTaskLibrary(

--- a/brickflow/engine/task_executor.py
+++ b/brickflow/engine/task_executor.py
@@ -1,5 +1,6 @@
 """Generic task executor for injected tasks."""
 
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -154,6 +155,100 @@ class GenericTaskExecutor:
         log.debug("Rendered template for %s:\n%s", task_def.task_name, rendered_code)
 
         return rendered_code
+
+    def render_template(self) -> str:
+        """Pre-render the template at deploy time so the code can be baked into the config."""
+        return self._load_and_render_template(self.task_def)
+
+    def serialize_for_runtime(self) -> str:
+        """
+        Render the template, write it to a local file that DAB will sync to the
+        workspace, and return a lightweight JSON pointer (no inline code).
+
+        The rendered ``.py`` file is placed under ``_brickflow_injected/`` in the
+        current working directory (the project root during ``bf projects deploy``).
+        DAB uploads everything in the project tree to
+        ``${workspace.file_path}/…`` so the file will be available on the cluster
+        at ``/Workspace/${workspace.file_path}/_brickflow_injected/<task>.py``.
+        """
+        rendered_code = self.render_template()
+
+        injected_dir = Path("_brickflow_injected")
+        injected_dir.mkdir(exist_ok=True)
+
+        file_name = f"{self.task_def.task_name}.py"
+        (injected_dir / file_name).write_text(rendered_code, encoding="utf-8")
+        log.info("Wrote injected task code to %s", injected_dir / file_name)
+
+        data: Dict[str, Any] = {
+            "task_name": self.task_def.task_name,
+            "task_type": self.task_def.task_type,
+            "file_ref": f"_brickflow_injected/{file_name}",
+        }
+        if self.task_def.artifact:
+            data["artifact"] = {
+                "url": self.task_def.artifact.url,
+                "install_as_library": self.task_def.artifact.install_as_library,
+            }
+        return json.dumps(data, separators=(",", ":"))
+
+    @staticmethod
+    def create_task_function_from_config(
+        config_json: str, workspace_file_path: Optional[str] = None
+    ) -> Callable:
+        """
+        Reconstruct a task function at runtime from baked injection config.
+
+        Prefers reading the rendered code from a workspace file that was synced
+        by DAB at deploy time.  Falls back to inline ``rendered_code`` in the
+        JSON for backward compatibility with older deployments.
+        """
+        config = json.loads(config_json)
+        task_name: str = config["task_name"]
+        artifact_cfg: Optional[Dict[str, Any]] = config.get("artifact")
+        inline_code: Optional[str] = config.get("rendered_code")
+
+        def injected_task_function() -> Any:
+            if artifact_cfg:
+                GenericTaskExecutor._download_and_setup_artifact(
+                    url=artifact_cfg["url"],
+                    username=None,
+                    api_key=None,
+                )
+
+            code: Optional[str] = None
+
+            if workspace_file_path:
+                try:
+                    with open(workspace_file_path, "r", encoding="utf-8") as fh:
+                        code = fh.read()
+                    log.info(
+                        "Loaded injected task code from workspace file: %s",
+                        workspace_file_path,
+                    )
+                except FileNotFoundError:
+                    log.warning(
+                        "Workspace file not found: %s — falling back to inline code",
+                        workspace_file_path,
+                    )
+
+            if code is None:
+                code = inline_code
+
+            if not code:
+                raise RuntimeError(
+                    f"No code available for injected task '{task_name}'. "
+                    "Neither workspace file nor inline rendered_code found in "
+                    "the injection config."
+                )
+
+            log.info("Executing injected task: %s", task_name)
+            local_vars: Dict[str, Any] = {}
+            exec(code, globals(), local_vars)  # pylint: disable=exec-used
+            return local_vars.get("result")
+
+        injected_task_function.__name__ = task_name
+        return injected_task_function
 
     @staticmethod
     def _download_and_setup_artifact(

--- a/brickflow/engine/workflow.py
+++ b/brickflow/engine/workflow.py
@@ -451,6 +451,7 @@ class Workflow:
         ensure_brickflow_plugins: bool = False,
         if_else_outcome: Optional[Dict[Union[str, str], str]] = None,
         for_each_task_conf: Optional[JobsTasksForEachTaskConfigs] = None,
+        injection_config_json: Optional[str] = None,
     ) -> None:
         if self.task_exists(task_id):
             raise TaskAlreadyExistsError(
@@ -517,6 +518,7 @@ class Workflow:
             ensure_brickflow_plugins=ensure_plugins,
             if_else_outcome=if_else_outcome,
             for_each_task_conf=for_each_task_conf,
+            injection_config_json=injection_config_json,
         )
 
         # attempt to create task object before adding to graph

--- a/tests/engine/test_task_injection.py
+++ b/tests/engine/test_task_injection.py
@@ -1006,5 +1006,261 @@ tasks:
         assert len(workflow.tasks) == 1  # Only task1
 
 
+class TestRuntimeInjectionReconstruction:
+    """Tests for file-based injection: serialize at deploy, reconstruct at runtime."""
+
+    def test_serialize_for_runtime_writes_file(self, tmp_path, monkeypatch):
+        """serialize_for_runtime writes a .py file and returns a JSON pointer."""
+        import json
+
+        monkeypatch.chdir(tmp_path)
+
+        template_file = tmp_path / "tmpl.py.j2"
+        template_file.write_text('result = "{{ greeting }}"')
+
+        task_def = TaskDefinition(
+            task_name="hello_task",
+            template_file=str(template_file),
+            template_context={"greeting": "hi_from_deploy"},
+        )
+
+        executor = GenericTaskExecutor(task_def)
+        config_json = executor.serialize_for_runtime()
+
+        config = json.loads(config_json)
+        assert config["task_name"] == "hello_task"
+        assert config["task_type"] == "BRICKFLOW_TASK"
+        assert config["file_ref"] == "_brickflow_injected/hello_task.py"
+        assert "rendered_code" not in config
+        assert "artifact" not in config
+
+        written = (tmp_path / "_brickflow_injected" / "hello_task.py").read_text()
+        assert 'result = "hi_from_deploy"' in written
+
+    def test_serialize_for_runtime_with_artifact(self, tmp_path, monkeypatch):
+        """Artifact metadata is preserved in the lightweight JSON pointer."""
+        import json
+        from brickflow.engine.task_injection_config import ArtifactConfig
+
+        monkeypatch.chdir(tmp_path)
+
+        template_file = tmp_path / "tmpl.py.j2"
+        template_file.write_text("result = 1")
+
+        task_def = TaskDefinition(
+            task_name="art_task",
+            template_file=str(template_file),
+            artifact=ArtifactConfig(
+                url="https://example.com/my.whl",
+                install_as_library=True,
+            ),
+        )
+
+        executor = GenericTaskExecutor(task_def)
+        config = json.loads(executor.serialize_for_runtime())
+
+        assert config["artifact"]["url"] == "https://example.com/my.whl"
+        assert config["artifact"]["install_as_library"] is True
+        assert config["file_ref"] == "_brickflow_injected/art_task.py"
+
+    def test_create_task_function_from_workspace_file(self, tmp_path):
+        """Runtime reads code from a workspace file when path is provided."""
+        import json
+
+        ws_file = tmp_path / "task_code.py"
+        ws_file.write_text('result = "from_workspace"')
+
+        config_json = json.dumps({
+            "task_name": "ws_task",
+            "task_type": "BRICKFLOW_TASK",
+            "file_ref": "_brickflow_injected/ws_task.py",
+        })
+
+        task_func = GenericTaskExecutor.create_task_function_from_config(
+            config_json, workspace_file_path=str(ws_file)
+        )
+
+        assert callable(task_func)
+        assert task_func.__name__ == "ws_task"
+        assert task_func() == "from_workspace"
+
+    def test_create_task_function_fallback_to_inline(self):
+        """Falls back to inline rendered_code for backward compat."""
+        import json
+
+        config_json = json.dumps({
+            "task_name": "legacy_task",
+            "task_type": "BRICKFLOW_TASK",
+            "rendered_code": 'result = "rebuilt"',
+        })
+
+        task_func = GenericTaskExecutor.create_task_function_from_config(config_json)
+
+        assert callable(task_func)
+        assert task_func.__name__ == "legacy_task"
+        assert task_func() == "rebuilt"
+
+    def test_create_task_function_file_missing_falls_back(self, tmp_path):
+        """When workspace file is missing, falls back to inline code."""
+        import json
+
+        config_json = json.dumps({
+            "task_name": "fallback_task",
+            "task_type": "BRICKFLOW_TASK",
+            "rendered_code": 'result = "inline_fallback"',
+        })
+
+        task_func = GenericTaskExecutor.create_task_function_from_config(
+            config_json, workspace_file_path=str(tmp_path / "does_not_exist.py")
+        )
+
+        assert task_func() == "inline_fallback"
+
+    def test_create_task_function_no_code_raises(self):
+        """Raises RuntimeError when neither file nor inline code is available."""
+        import json
+
+        config_json = json.dumps({
+            "task_name": "empty_task",
+            "task_type": "BRICKFLOW_TASK",
+        })
+
+        task_func = GenericTaskExecutor.create_task_function_from_config(config_json)
+
+        with pytest.raises(RuntimeError, match="No code available"):
+            task_func()
+
+    def test_injection_config_json_stored_on_task(self, tmp_path, monkeypatch):
+        """Injection config with file_ref is stored on the Task after injection."""
+        monkeypatch.chdir(tmp_path)
+
+        template_file = tmp_path / "tmpl.py.j2"
+        template_file.write_text("result = 42")
+
+        yaml_content = f"""
+global:
+  enabled: true
+
+tasks:
+  - task_name: "injected_task"
+    enabled: true
+    template_file: "{template_file}"
+    depends_on_strategy: "leaf_nodes"
+"""
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text(yaml_content)
+
+        workflow = Workflow("test_workflow")
+
+        @workflow.task()
+        def original_task():
+            return "original"
+
+        from brickflow.engine.project import _Project
+
+        project = _Project(name="test_project")
+
+        with patch.dict(
+            os.environ, {"BRICKFLOW_INJECT_TASKS_CONFIG": str(yaml_file)}
+        ):
+            project._inject_tasks_from_yaml(workflow)
+
+        assert "injected_task" in workflow.tasks
+        injected = workflow.tasks["injected_task"]
+        assert injected.injection_config_json is not None
+
+        import json
+
+        baked = json.loads(injected.injection_config_json)
+        assert baked["task_name"] == "injected_task"
+        assert baked["file_ref"] == "_brickflow_injected/injected_task.py"
+
+    def test_reconstruct_injected_task_from_workspace_file(self, tmp_path, monkeypatch):
+        """End-to-end: serialize at deploy, reconstruct from workspace file at runtime."""
+        import json
+
+        monkeypatch.chdir(tmp_path)
+
+        template_file = tmp_path / "tmpl.py.j2"
+        template_file.write_text('result = "runtime_ok"')
+
+        yaml_content = f"""
+global:
+  enabled: true
+
+tasks:
+  - task_name: "compliance_task"
+    enabled: true
+    template_file: "{template_file}"
+    depends_on_strategy: "leaf_nodes"
+"""
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text(yaml_content)
+
+        workflow = Workflow("my_workflow")
+
+        @workflow.task()
+        def setup():
+            return "setup"
+
+        from brickflow.engine.project import _Project, Project
+        from brickflow.context import BrickflowInternalVariables
+
+        project = _Project(name="test_project")
+
+        with patch.dict(
+            os.environ, {"BRICKFLOW_INJECT_TASKS_CONFIG": str(yaml_file)}
+        ):
+            project._inject_tasks_from_yaml(workflow)
+
+        baked_json = workflow.tasks["compliance_task"].injection_config_json
+        assert baked_json is not None
+
+        ws_file = tmp_path / "_brickflow_injected" / "compliance_task.py"
+        assert ws_file.exists()
+
+        runtime_workflow = Workflow("my_workflow")
+
+        @runtime_workflow.task()
+        def setup_rt():  # noqa: F811
+            return "setup"
+
+        assert "compliance_task" not in runtime_workflow.tasks
+
+        def _mock_get_parameter(name, default=None):
+            if name == BrickflowInternalVariables.injection_config.value:
+                return baked_json
+            if name == BrickflowInternalVariables.injection_file_path.value:
+                return str(ws_file)
+            return default
+
+        with patch("brickflow.engine.project.ctx") as mock_ctx:
+            mock_ctx.get_parameter.side_effect = _mock_get_parameter
+            task = Project._reconstruct_injected_task(
+                runtime_workflow, "compliance_task"
+            )
+
+        assert task is not None
+        assert task.name == "compliance_task"
+        assert "compliance_task" in runtime_workflow.tasks
+
+    def test_reconstruct_raises_without_baked_config(self):
+        """Reconstruction must fail clearly when no baked config is available."""
+        from brickflow.engine.project import Project
+        from brickflow.engine.task import TaskNotFoundError
+
+        workflow = Workflow("my_workflow")
+
+        @workflow.task()
+        def task1():
+            return "task1"
+
+        with patch("brickflow.engine.project.ctx") as mock_ctx:
+            mock_ctx.get_parameter.return_value = None
+
+            with pytest.raises(TaskNotFoundError, match="compliance_task"):
+                Project._reconstruct_injected_task(workflow, "compliance_task")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Injected tasks deployed via `BRICKFLOW_INJECT_TASKS_DIR` fail at runtime because the injection YAML/env vars only exist on the CI agent, not on the Databricks cluster. This PR writes the rendered template code to workspace files that the cluster can read at runtime.

## Problem

When Brickflow deploys a job with injected tasks, the job definition on Databricks correctly includes those tasks. But when the cluster re-executes the entrypoint notebook, `BRICKFLOW_INJECT_TASKS_DIR` is not set, so `_inject_tasks_from_yaml()` is a no-op and `workflow.get_task(task_id)` raises `TaskNotFoundError`.

## Solution

### Deploy time

1. `serialize_for_runtime()` renders the Jinja template and writes the output to `_brickflow_injected/<task_name>.py` in the project directory
2. A lightweight JSON pointer (`task_name`, `task_type`, `file_ref`) is stored in `brickflow_internal_injection_config` — no inline source code
3. The resolved workspace path is stored in `brickflow_internal_injection_file_path` using DAB's `${workspace.file_path}` interpolation
4. `synth()` adds `sync.include: ["_brickflow_injected/**"]` to the bundle config so DAB uploads the files even when the directory is gitignored

### Runtime

1. If `workflow.get_task(t_id)` fails, `_reconstruct_injected_task()` reads `brickflow_internal_injection_file_path` from the task parameters
2. Opens the `.py` file from the workspace filesystem (`/Workspace/Users/.../.brickflow_bundles/.../files/_brickflow_injected/<task>.py`)
3. Falls back to inline `rendered_code` in the JSON for backward compatibility with older deployments
4. Reconstructs the `Task` object and executes normally

### Why files instead of base_parameters?

The previous approach serialized the full rendered source into `base_parameters` as a JSON string. This was fragile:
- Databricks has practical size limits on parameter values (~10KB)
- Double/triple escaping (Python inside JSON inside YAML)
- Harder to debug — code invisible in the workspace

With workspace files, the rendered code is inspectable in the Databricks UI, has no size limit, and the deploy→runtime contract is a simple file path.

## Files changed

| File | Change |
|------|--------|
| `brickflow/context/context.py` | Add `injection_config` and `injection_file_path` to `BrickflowInternalVariables` |
| `brickflow/engine/task_executor.py` | Write rendered code to file in `serialize_for_runtime()`; read from workspace file in `create_task_function_from_config()` |
| `brickflow/engine/task.py` | Add `injection_config_json` field; emit `${workspace.file_path}` parameter |
| `brickflow/engine/workflow.py` | Thread `injection_config_json` through `_add_task` |
| `brickflow/engine/project.py` | Serialize config at deploy; reconstruct task from workspace file at runtime |
| `brickflow/codegen/databricks_bundle.py` | Add `Sync(include=["_brickflow_injected/**"])` when injected files exist |
| `tests/engine/test_task_injection.py` | Tests for file writing, workspace file reading, inline fallback, missing file fallback, no-code error |

## Test plan

- [x] All 38 task injection tests pass (including new file-based tests)
- [x] `bundle.yml` contains lightweight JSON pointer (no inline code)
- [x] `bundle.yml` contains `sync.include` for `_brickflow_injected/`
- [x] Files confirmed on Databricks workspace via API
- [x] End-to-end: injected task runs successfully on sole-blazer cluster
- [ ] Verify with larger templates to confirm no size issues

## Pre-review cleanup

- [ ] **Remove `BRICKFLOW_RUNTIME_GIT_REF` override** from `get_brickflow_libraries()` in `task.py` — temporary hack to point the cluster at this fork for e2e testing

Closes nike-cdea-privacy/sidecar-test-zone-tmp#8